### PR TITLE
Const correctness of pointers in gather

### DIFF
--- a/UMESimdInterface.h
+++ b/UMESimdInterface.h
@@ -2505,13 +2505,13 @@ namespace SIMD
         }
 
         // GATHERS
-        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (SCALAR_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (SCALAR_TYPE const * baseAddr, SCALAR_UINT_TYPE const * indices) {
             UME_EMULATION_WARNING();
             return SCALAR_EMULATION::gather<DERIVED_VEC_TYPE, SCALAR_TYPE, SCALAR_UINT_TYPE> (static_cast<DERIVED_VEC_TYPE &>(*this), baseAddr, indices);
         }
 
         // MGATHERS
-        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (MASK_TYPE const & mask, SCALAR_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (MASK_TYPE const & mask, SCALAR_TYPE const * baseAddr, SCALAR_UINT_TYPE const * indices) {
             UME_EMULATION_WARNING();
             return SCALAR_EMULATION::gather<DERIVED_VEC_TYPE, SCALAR_TYPE, SCALAR_UINT_TYPE, MASK_TYPE> (mask, static_cast<DERIVED_VEC_TYPE &>(*this), baseAddr, indices);
         }

--- a/UMESimdInterface.h
+++ b/UMESimdInterface.h
@@ -2493,37 +2493,37 @@ namespace SIMD
  
     public:
         // GATHERU
-        UME_FORCE_INLINE DERIVED_VEC_TYPE & gatheru (SCALAR_TYPE * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE DERIVED_VEC_TYPE & gatheru (SCALAR_TYPE const * baseAddr, uint32_t stride) {
             UME_EMULATION_WARNING();
             return SCALAR_EMULATION::gatheru<DERIVED_VEC_TYPE, SCALAR_TYPE> (static_cast<DERIVED_VEC_TYPE &>(*this), baseAddr, stride);
         }
 
         // MGATHERU
-        UME_FORCE_INLINE DERIVED_VEC_TYPE & gatheru (MASK_TYPE const & mask, SCALAR_TYPE * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE DERIVED_VEC_TYPE & gatheru (MASK_TYPE const & mask, SCALAR_TYPE const * baseAddr, uint32_t stride) {
             UME_EMULATION_WARNING();
             return SCALAR_EMULATION::gatheru<DERIVED_VEC_TYPE, SCALAR_TYPE, MASK_TYPE> (mask, static_cast<DERIVED_VEC_TYPE &>(*this), baseAddr, stride);
         }
 
         // GATHERS
-        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (SCALAR_TYPE * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (SCALAR_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
             UME_EMULATION_WARNING();
             return SCALAR_EMULATION::gather<DERIVED_VEC_TYPE, SCALAR_TYPE, SCALAR_UINT_TYPE> (static_cast<DERIVED_VEC_TYPE &>(*this), baseAddr, indices);
         }
 
         // MGATHERS
-        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (MASK_TYPE const & mask, SCALAR_TYPE* baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (MASK_TYPE const & mask, SCALAR_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
             UME_EMULATION_WARNING();
             return SCALAR_EMULATION::gather<DERIVED_VEC_TYPE, SCALAR_TYPE, SCALAR_UINT_TYPE, MASK_TYPE> (mask, static_cast<DERIVED_VEC_TYPE &>(*this), baseAddr, indices);
         }
 
         // GATHERV
-        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (SCALAR_TYPE * baseAddr, DERIVED_UINT_VEC_TYPE const & indices) {
+        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (SCALAR_TYPE const * baseAddr, DERIVED_UINT_VEC_TYPE const & indices) {
             UME_EMULATION_WARNING();
             return SCALAR_EMULATION::gather<DERIVED_VEC_TYPE, SCALAR_TYPE, DERIVED_UINT_VEC_TYPE> (static_cast<DERIVED_VEC_TYPE &>(*this), baseAddr, indices);
         }
 
         // MGATHERV
-        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (MASK_TYPE const & mask, SCALAR_TYPE* baseAddr, DERIVED_UINT_VEC_TYPE const & indices) {
+        UME_FORCE_INLINE DERIVED_VEC_TYPE & gather (MASK_TYPE const & mask, SCALAR_TYPE const * baseAddr, DERIVED_UINT_VEC_TYPE const & indices) {
             UME_EMULATION_WARNING();
             return SCALAR_EMULATION::gather<DERIVED_VEC_TYPE, SCALAR_TYPE, DERIVED_UINT_VEC_TYPE, MASK_TYPE> (mask, static_cast<DERIVED_VEC_TYPE &>(*this), baseAddr, indices);
         }

--- a/UMESimdScalarEmulation.h
+++ b/UMESimdScalarEmulation.h
@@ -170,7 +170,7 @@ namespace SCALAR_EMULATION
     
     // GATHERS
     template<typename VEC_TYPE, typename SCALAR_TYPE, typename SCALAR_UINT_TYPE>
-    UME_FORCE_INLINE VEC_TYPE & gather(VEC_TYPE & dst, SCALAR_TYPE const * base, SCALAR_UINT_TYPE* indices) {
+    UME_FORCE_INLINE VEC_TYPE & gather(VEC_TYPE & dst, SCALAR_TYPE const * base, SCALAR_UINT_TYPE const * indices) {
         for (uint32_t i = 0; i < VEC_TYPE::length(); i++) {
             dst.insert(i, base[indices[i]]);
         }
@@ -179,7 +179,7 @@ namespace SCALAR_EMULATION
 
     // MGATHERS
     template<typename VEC_TYPE, typename SCALAR_TYPE, typename SCALAR_UINT_TYPE, typename MASK_TYPE>
-    UME_FORCE_INLINE VEC_TYPE & gather(MASK_TYPE const & mask, VEC_TYPE & dst, SCALAR_TYPE const * base, SCALAR_UINT_TYPE* indices) {
+    UME_FORCE_INLINE VEC_TYPE & gather(MASK_TYPE const & mask, VEC_TYPE & dst, SCALAR_TYPE const * base, SCALAR_UINT_TYPE const * indices) {
         for (uint32_t i = 0; i < VEC_TYPE::length(); i++) {
             if (mask[i] == true) dst.insert(i, base[indices[i]]);
         }

--- a/UMESimdScalarEmulation.h
+++ b/UMESimdScalarEmulation.h
@@ -152,7 +152,7 @@ namespace SCALAR_EMULATION
     
     // GATHERU
     template<typename VEC_TYPE, typename SCALAR_TYPE>
-    UME_FORCE_INLINE VEC_TYPE & gatheru(VEC_TYPE & dst, SCALAR_TYPE* base, uint32_t stride) {
+    UME_FORCE_INLINE VEC_TYPE & gatheru(VEC_TYPE & dst, SCALAR_TYPE const * base, uint32_t stride) {
         for (uint32_t i = 0; i < VEC_TYPE::length(); i++) {
             dst.insert(i, base[i*stride]);
         }
@@ -161,7 +161,7 @@ namespace SCALAR_EMULATION
 
     // MGATHERU
     template<typename VEC_TYPE, typename SCALAR_TYPE, typename MASK_TYPE>
-    UME_FORCE_INLINE VEC_TYPE & gatheru(MASK_TYPE const & mask, VEC_TYPE & dst, SCALAR_TYPE* base, uint32_t stride) {
+    UME_FORCE_INLINE VEC_TYPE & gatheru(MASK_TYPE const & mask, VEC_TYPE & dst, SCALAR_TYPE const * base, uint32_t stride) {
         for (uint32_t i = 0; i < VEC_TYPE::length(); i++) {
             if (mask[i] == true) dst.insert(i, base[i*stride]);
         }
@@ -170,7 +170,7 @@ namespace SCALAR_EMULATION
     
     // GATHERS
     template<typename VEC_TYPE, typename SCALAR_TYPE, typename SCALAR_UINT_TYPE>
-    UME_FORCE_INLINE VEC_TYPE & gather(VEC_TYPE & dst, SCALAR_TYPE* base, SCALAR_UINT_TYPE* indices) {
+    UME_FORCE_INLINE VEC_TYPE & gather(VEC_TYPE & dst, SCALAR_TYPE const * base, SCALAR_UINT_TYPE* indices) {
         for (uint32_t i = 0; i < VEC_TYPE::length(); i++) {
             dst.insert(i, base[indices[i]]);
         }
@@ -179,7 +179,7 @@ namespace SCALAR_EMULATION
 
     // MGATHERS
     template<typename VEC_TYPE, typename SCALAR_TYPE, typename SCALAR_UINT_TYPE, typename MASK_TYPE>
-    UME_FORCE_INLINE VEC_TYPE & gather(MASK_TYPE const & mask, VEC_TYPE & dst, SCALAR_TYPE* base, SCALAR_UINT_TYPE* indices) {
+    UME_FORCE_INLINE VEC_TYPE & gather(MASK_TYPE const & mask, VEC_TYPE & dst, SCALAR_TYPE const * base, SCALAR_UINT_TYPE* indices) {
         for (uint32_t i = 0; i < VEC_TYPE::length(); i++) {
             if (mask[i] == true) dst.insert(i, base[indices[i]]);
         }
@@ -188,7 +188,7 @@ namespace SCALAR_EMULATION
 
     // GATHERV
     template<typename VEC_TYPE, typename SCALAR_TYPE, typename UINT_VEC_TYPE>
-    UME_FORCE_INLINE VEC_TYPE & gather(VEC_TYPE & dst, SCALAR_TYPE* base, UINT_VEC_TYPE const & indices) {
+    UME_FORCE_INLINE VEC_TYPE & gather(VEC_TYPE & dst, SCALAR_TYPE const * base, UINT_VEC_TYPE const & indices) {
         for (uint32_t i = 0; i < VEC_TYPE::length(); i++) {
             dst.insert(i, base[indices[i]]);
         }
@@ -197,7 +197,7 @@ namespace SCALAR_EMULATION
 
     // MGATHERV
     template<typename VEC_TYPE, typename SCALAR_TYPE, typename UINT_VEC_TYPE, typename MASK_TYPE>
-    UME_FORCE_INLINE VEC_TYPE & gather(MASK_TYPE const & mask, VEC_TYPE & dst, SCALAR_TYPE* base, UINT_VEC_TYPE const & indices) {
+    UME_FORCE_INLINE VEC_TYPE & gather(MASK_TYPE const & mask, VEC_TYPE & dst, SCALAR_TYPE const * base, UINT_VEC_TYPE const & indices) {
         for (uint32_t i = 0; i < VEC_TYPE::length(); i++) {
             if (mask[i] == true) dst.insert(i, base[indices[i]]);
         }

--- a/plugins/arm/float/UMESimdVecFloat32_1.h
+++ b/plugins/arm/float/UMESimdVecFloat32_1.h
@@ -886,12 +886,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/arm/float/UMESimdVecFloat32_1.h
+++ b/plugins/arm/float/UMESimdVecFloat32_1.h
@@ -886,22 +886,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/arm/float/UMESimdVecFloat32_2.h
+++ b/plugins/arm/float/UMESimdVecFloat32_2.h
@@ -1062,25 +1062,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/arm/float/UMESimdVecFloat32_2.h
+++ b/plugins/arm/float/UMESimdVecFloat32_2.h
@@ -1062,13 +1062,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/arm/float/UMESimdVecFloat32_4.h
+++ b/plugins/arm/float/UMESimdVecFloat32_4.h
@@ -1509,7 +1509,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -1517,7 +1517,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];

--- a/plugins/arm/float/UMESimdVecFloat32_4.h
+++ b/plugins/arm/float/UMESimdVecFloat32_4.h
@@ -1509,7 +1509,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -1517,7 +1517,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -1525,7 +1525,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -1533,7 +1533,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/arm/float/UMESimdVecFloat32_8.h
+++ b/plugins/arm/float/UMESimdVecFloat32_8.h
@@ -2290,7 +2290,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2302,7 +2302,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -2314,7 +2314,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -2326,7 +2326,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/arm/float/UMESimdVecFloat32_8.h
+++ b/plugins/arm/float/UMESimdVecFloat32_8.h
@@ -2290,7 +2290,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2302,7 +2302,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];

--- a/plugins/arm/int/UMESimdVecInt32_1.h
+++ b/plugins/arm/int/UMESimdVecInt32_1.h
@@ -1273,12 +1273,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/arm/int/UMESimdVecInt32_1.h
+++ b/plugins/arm/int/UMESimdVecInt32_1.h
@@ -1273,22 +1273,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<1> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/arm/int/UMESimdVecInt32_2.h
+++ b/plugins/arm/int/UMESimdVecInt32_2.h
@@ -1487,25 +1487,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/arm/int/UMESimdVecInt32_2.h
+++ b/plugins/arm/int/UMESimdVecInt32_2.h
@@ -1487,13 +1487,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/arm/int/UMESimdVecInt32_4.h
+++ b/plugins/arm/int/UMESimdVecInt32_4.h
@@ -1835,7 +1835,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -1843,7 +1843,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];

--- a/plugins/arm/int/UMESimdVecInt32_4.h
+++ b/plugins/arm/int/UMESimdVecInt32_4.h
@@ -1835,7 +1835,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -1843,7 +1843,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -1851,7 +1851,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, SIMDVec_i const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_i const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -1859,7 +1859,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t* baseAddr, SIMDVec_i const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, SIMDVec_i const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/arm/int/UMESimdVecInt32_8.h
+++ b/plugins/arm/int/UMESimdVecInt32_8.h
@@ -2660,7 +2660,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2672,7 +2672,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -2684,7 +2684,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -2696,7 +2696,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/arm/int/UMESimdVecInt32_8.h
+++ b/plugins/arm/int/UMESimdVecInt32_8.h
@@ -2660,7 +2660,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2672,7 +2672,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];

--- a/plugins/arm/uint/UMESimdVecUint32_1.h
+++ b/plugins/arm/uint/UMESimdVecUint32_1.h
@@ -1169,22 +1169,22 @@ namespace SIMD {
         }
 
         // GATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u gather(SIMDVecMask<1> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/arm/uint/UMESimdVecUint32_1.h
+++ b/plugins/arm/uint/UMESimdVecUint32_1.h
@@ -1169,12 +1169,12 @@ namespace SIMD {
         }
 
         // GATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/arm/uint/UMESimdVecUint32_2.h
+++ b/plugins/arm/uint/UMESimdVecUint32_2.h
@@ -1386,13 +1386,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/arm/uint/UMESimdVecUint32_2.h
+++ b/plugins/arm/uint/UMESimdVecUint32_2.h
@@ -1386,25 +1386,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/arm/uint/UMESimdVecUint32_4.h
+++ b/plugins/arm/uint/UMESimdVecUint32_4.h
@@ -1763,7 +1763,7 @@ namespace SIMD {
 
         */
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             UME_EMULATION_WARNING();
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
@@ -1772,7 +1772,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             UME_EMULATION_WARNING();
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
@@ -1781,7 +1781,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             alignas(32) uint32_t raw_indices[4];
             alignas(32) uint32_t raw_data[4];
             vst1q_u32(raw_indices, indices.mVec);
@@ -1793,7 +1793,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             UME_EMULATION_WARNING();
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];

--- a/plugins/arm/uint/UMESimdVecUint32_4.h
+++ b/plugins/arm/uint/UMESimdVecUint32_4.h
@@ -1763,7 +1763,7 @@ namespace SIMD {
 
         */
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             UME_EMULATION_WARNING();
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
@@ -1772,7 +1772,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             UME_EMULATION_WARNING();
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];

--- a/plugins/arm/uint/UMESimdVecUint32_8.h
+++ b/plugins/arm/uint/UMESimdVecUint32_8.h
@@ -2654,7 +2654,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2666,7 +2666,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -2678,7 +2678,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -2690,7 +2690,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/arm/uint/UMESimdVecUint32_8.h
+++ b/plugins/arm/uint/UMESimdVecUint32_8.h
@@ -2654,7 +2654,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2666,7 +2666,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];

--- a/plugins/avx/float/UMESimdVecFloat32_1.h
+++ b/plugins/avx/float/UMESimdVecFloat32_1.h
@@ -887,12 +887,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx/float/UMESimdVecFloat32_1.h
+++ b/plugins/avx/float/UMESimdVecFloat32_1.h
@@ -887,22 +887,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(float * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(float * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx/float/UMESimdVecFloat32_2.h
+++ b/plugins/avx/float/UMESimdVecFloat32_2.h
@@ -1063,25 +1063,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(float * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(float * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx/float/UMESimdVecFloat32_2.h
+++ b/plugins/avx/float/UMESimdVecFloat32_2.h
@@ -1063,13 +1063,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx/float/UMESimdVecFloat64_1.h
+++ b/plugins/avx/float/UMESimdVecFloat64_1.h
@@ -887,22 +887,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(double * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, uint64_t * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, uint64_t * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(double * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx/float/UMESimdVecFloat64_1.h
+++ b/plugins/avx/float/UMESimdVecFloat64_1.h
@@ -887,12 +887,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(double const * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, uint64_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx/float/UMESimdVecFloat64_2.h
+++ b/plugins/avx/float/UMESimdVecFloat64_2.h
@@ -1045,13 +1045,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(double const * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx/float/UMESimdVecFloat64_2.h
+++ b/plugins/avx/float/UMESimdVecFloat64_2.h
@@ -1045,25 +1045,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(double * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, uint64_t * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(double * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx/int/UMESimdVecInt32_1.h
+++ b/plugins/avx/int/UMESimdVecInt32_1.h
@@ -1274,22 +1274,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
+        inline SIMDVec_i gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i gather(SIMDVecMask<1> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
+        inline SIMDVec_i gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx/int/UMESimdVecInt32_1.h
+++ b/plugins/avx/int/UMESimdVecInt32_1.h
@@ -1274,12 +1274,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx/int/UMESimdVecInt32_2.h
+++ b/plugins/avx/int/UMESimdVecInt32_2.h
@@ -1488,13 +1488,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx/int/UMESimdVecInt32_2.h
+++ b/plugins/avx/int/UMESimdVecInt32_2.h
@@ -1488,25 +1488,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
+        inline SIMDVec_i gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
+        inline SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx/int/UMESimdVecInt32_4.h
+++ b/plugins/avx/int/UMESimdVecInt32_4.h
@@ -1210,20 +1210,20 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             alignas(16) int32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             mVec = _mm_load_si128((__m128i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             alignas(16) int32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             __m128i t0 = _mm_load_si128((__m128i*)raw);
             mVec = _mm_blendv_epi8(mVec, t0, mask.mMask);
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i & gather(int32_t* baseAddr, SIMDVec_i const & indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_i const & indices) {
             alignas(16) int32_t rawInd[4];
             alignas(16) int32_t raw[4];
 
@@ -1233,7 +1233,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t* baseAddr, SIMDVec_i const & indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, SIMDVec_i const & indices) {
             alignas(16) int32_t rawInd[4];
             alignas(16) int32_t raw[4];
 

--- a/plugins/avx/int/UMESimdVecInt32_4.h
+++ b/plugins/avx/int/UMESimdVecInt32_4.h
@@ -1210,13 +1210,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             alignas(16) int32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             mVec = _mm_load_si128((__m128i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             alignas(16) int32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             __m128i t0 = _mm_load_si128((__m128i*)raw);
             mVec = _mm_blendv_epi8(mVec, t0, mask.mMask);

--- a/plugins/avx/int/UMESimdVecInt32_8.h
+++ b/plugins/avx/int/UMESimdVecInt32_8.h
@@ -1661,14 +1661,14 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_i & gather(int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             alignas(32) int32_t raw[8] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]],
                 baseAddr[indices[4]], baseAddr[indices[5]], baseAddr[indices[6]], baseAddr[indices[7]] };
             mVec = _mm256_load_si256((__m256i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             alignas(32) int32_t raw[8] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]],
                 baseAddr[indices[4]], baseAddr[indices[5]], baseAddr[indices[6]], baseAddr[indices[7]] };
             __m128i a_low = _mm256_extractf128_si256(mVec, 0);
@@ -1684,7 +1684,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i & gather(int32_t* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             alignas(32) int32_t rawInd[8];
             alignas(32) int32_t raw[8];
 
@@ -1694,7 +1694,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             alignas(32) int32_t rawInd[8];
             alignas(32) int32_t raw[8];
 

--- a/plugins/avx/int/UMESimdVecInt32_8.h
+++ b/plugins/avx/int/UMESimdVecInt32_8.h
@@ -1661,14 +1661,14 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             alignas(32) int32_t raw[8] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]],
                 baseAddr[indices[4]], baseAddr[indices[5]], baseAddr[indices[6]], baseAddr[indices[7]] };
             mVec = _mm256_load_si256((__m256i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             alignas(32) int32_t raw[8] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]],
                 baseAddr[indices[4]], baseAddr[indices[5]], baseAddr[indices[6]], baseAddr[indices[7]] };
             __m128i a_low = _mm256_extractf128_si256(mVec, 0);

--- a/plugins/avx/int/UMESimdVecInt64_1.h
+++ b/plugins/avx/int/UMESimdVecInt64_1.h
@@ -1273,12 +1273,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx/int/UMESimdVecInt64_1.h
+++ b/plugins/avx/int/UMESimdVecInt64_1.h
@@ -1273,22 +1273,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int64_t * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t* baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, uint64_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i gather(int64_t * baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
+        inline SIMDVec_i gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i gather(SIMDVecMask<1> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
+        inline SIMDVec_i gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx/int/UMESimdVecInt64_2.h
+++ b/plugins/avx/int/UMESimdVecInt64_2.h
@@ -1487,13 +1487,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx/int/UMESimdVecInt64_2.h
+++ b/plugins/avx/int/UMESimdVecInt64_2.h
@@ -1487,25 +1487,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int64_t * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t* baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i gather(int64_t * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
+        inline SIMDVec_i gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i gather(SIMDVecMask<2> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
+        inline SIMDVec_i gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx/uint/UMESimdVecUint32_1.h
+++ b/plugins/avx/uint/UMESimdVecUint32_1.h
@@ -1170,12 +1170,12 @@ namespace SIMD {
         }
 
         // GATHER
-        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx/uint/UMESimdVecUint32_1.h
+++ b/plugins/avx/uint/UMESimdVecUint32_1.h
@@ -1170,22 +1170,22 @@ namespace SIMD {
         }
 
         // GATHER
-        inline SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u gather(SIMDVecMask<1> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx/uint/UMESimdVecUint32_2.h
+++ b/plugins/avx/uint/UMESimdVecUint32_2.h
@@ -1387,25 +1387,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u & gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx/uint/UMESimdVecUint32_2.h
+++ b/plugins/avx/uint/UMESimdVecUint32_2.h
@@ -1387,13 +1387,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx/uint/UMESimdVecUint32_4.h
+++ b/plugins/avx/uint/UMESimdVecUint32_4.h
@@ -1186,20 +1186,20 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             alignas(16) uint32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             mVec = _mm_load_si128((__m128i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             alignas(16) uint32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             __m128i t0 = _mm_load_si128((__m128i*)raw);
             mVec = _mm_blendv_epi8(mVec, t0, mask.mMask);
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u & gather(uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             alignas(16) uint32_t rawInd[4];
             alignas(16) uint32_t raw[4];
 
@@ -1209,7 +1209,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             alignas(16) uint32_t rawInd[4];
             alignas(16) uint32_t raw[4];
 

--- a/plugins/avx/uint/UMESimdVecUint32_4.h
+++ b/plugins/avx/uint/UMESimdVecUint32_4.h
@@ -1186,13 +1186,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             alignas(16) uint32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             mVec = _mm_load_si128((__m128i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             alignas(16) uint32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             __m128i t0 = _mm_load_si128((__m128i*)raw);
             mVec = _mm_blendv_epi8(mVec, t0, mask.mMask);

--- a/plugins/avx/uint/UMESimdVecUint32_8.h
+++ b/plugins/avx/uint/UMESimdVecUint32_8.h
@@ -1666,14 +1666,14 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             alignas(32) uint32_t raw[8] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]],
                 baseAddr[indices[4]], baseAddr[indices[5]], baseAddr[indices[6]], baseAddr[indices[7]] };
             mVec = _mm256_load_si256((__m256i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             alignas(32) uint32_t raw[8] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]],
                 baseAddr[indices[4]], baseAddr[indices[5]], baseAddr[indices[6]], baseAddr[indices[7]] };
             __m128i a_low = _mm256_extractf128_si256(mVec, 0);
@@ -1689,7 +1689,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u & gather(uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             alignas(32) uint32_t rawInd[8];
             alignas(32) uint32_t raw[8];
 
@@ -1699,7 +1699,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             alignas(32) uint32_t rawInd[8];
             alignas(32) uint32_t raw[8];
 

--- a/plugins/avx/uint/UMESimdVecUint32_8.h
+++ b/plugins/avx/uint/UMESimdVecUint32_8.h
@@ -1666,14 +1666,14 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             alignas(32) uint32_t raw[8] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]],
                 baseAddr[indices[4]], baseAddr[indices[5]], baseAddr[indices[6]], baseAddr[indices[7]] };
             mVec = _mm256_load_si256((__m256i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             alignas(32) uint32_t raw[8] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]],
                 baseAddr[indices[4]], baseAddr[indices[5]], baseAddr[indices[6]], baseAddr[indices[7]] };
             __m128i a_low = _mm256_extractf128_si256(mVec, 0);

--- a/plugins/avx/uint/UMESimdVecUint64_1.h
+++ b/plugins/avx/uint/UMESimdVecUint64_1.h
@@ -1170,22 +1170,22 @@ namespace SIMD {
         }
 
         // GATHER
-        inline SIMDVec_u & gather(uint64_t * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t* baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u gather(uint64_t * baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u gather(SIMDVecMask<1> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx/uint/UMESimdVecUint64_1.h
+++ b/plugins/avx/uint/UMESimdVecUint64_1.h
@@ -1170,12 +1170,12 @@ namespace SIMD {
         }
 
         // GATHER
-        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx/uint/UMESimdVecUint64_2.h
+++ b/plugins/avx/uint/UMESimdVecUint64_2.h
@@ -1387,25 +1387,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint64_t * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t* baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u & gather(uint64_t * baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx/uint/UMESimdVecUint64_2.h
+++ b/plugins/avx/uint/UMESimdVecUint64_2.h
@@ -1387,13 +1387,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx2/float/UMESimdVecFloat32_1.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_1.h
@@ -887,12 +887,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx2/float/UMESimdVecFloat32_1.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_1.h
@@ -887,22 +887,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(float * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(float * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx2/float/UMESimdVecFloat32_16.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_16.h
@@ -1349,7 +1349,7 @@ namespace SIMD {
         // MIMIN
 
         // GATHERS
-        inline SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_load_si256((__m256i*)indices);
             mVec[0] = _mm256_i32gather_ps((const float *)baseAddr, t0, 4);
             __m256i t1 = _mm256_load_si256((__m256i*)(indices + 8));
@@ -1357,7 +1357,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<16> const & mask, float const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<16> const & mask, float const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256 t1 = _mm256_i32gather_ps((const float *)baseAddr, t0, 4);
             mVec[0] = BLEND(mVec[0], t1, mask.mMask[0]);

--- a/plugins/avx2/float/UMESimdVecFloat32_16.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_16.h
@@ -1349,7 +1349,7 @@ namespace SIMD {
         // MIMIN
 
         // GATHERS
-        inline SIMDVec_f & gather(float* baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_load_si256((__m256i*)indices);
             mVec[0] = _mm256_i32gather_ps((const float *)baseAddr, t0, 4);
             __m256i t1 = _mm256_load_si256((__m256i*)(indices + 8));
@@ -1357,7 +1357,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<16> const & mask, float* baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<16> const & mask, float const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256 t1 = _mm256_i32gather_ps((const float *)baseAddr, t0, 4);
             mVec[0] = BLEND(mVec[0], t1, mask.mMask[0]);
@@ -1367,13 +1367,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(float* baseAddr, SIMDVec_u<uint32_t, 16> const & indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 16> const & indices) {
             mVec[0] = _mm256_i32gather_ps((const float *)baseAddr, indices.mVec[0], 4);
             mVec[1] = _mm256_i32gather_ps((const float *)baseAddr, indices.mVec[1], 4);
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<16> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 16> const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<16> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 16> const & indices) {
             __m256 t0 = _mm256_i32gather_ps((const float *)baseAddr, indices.mVec[0], 4);
             mVec[0] = BLEND(mVec[0], t0, mask.mMask[0]);
             __m256 t1 = _mm256_i32gather_ps((const float *)baseAddr, indices.mVec[1], 4);

--- a/plugins/avx2/float/UMESimdVecFloat32_2.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_2.h
@@ -1063,25 +1063,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(float * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(float * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx2/float/UMESimdVecFloat32_2.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_2.h
@@ -1063,13 +1063,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx2/float/UMESimdVecFloat32_4.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_4.h
@@ -990,25 +990,25 @@ namespace SIMD {
         // MIMIN
 
         // GATHERS
-        inline SIMDVec_f & gather(float* baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             __m128i t0 = _mm_load_si128((__m128i*)indices);
             mVec = _mm_i32gather_ps((const float *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<4> const & mask, float* baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t* indices) {
             __m128i t0 = _mm_load_si128((__m128i*)indices);
             __m128 t1 = _mm_i32gather_ps((const float *)baseAddr, t0, 4);
             mVec = BLEND(mVec, t1, mask.mMask);
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(float* baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
             mVec = _mm_i32gather_ps((const float *)baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<4> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
             __m128 t0 = _mm_i32gather_ps((const float *)baseAddr, indices.mVec, 4);
             mVec = BLEND(mVec, t0, mask.mMask);
             return *this;

--- a/plugins/avx2/float/UMESimdVecFloat32_4.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_4.h
@@ -990,13 +990,13 @@ namespace SIMD {
         // MIMIN
 
         // GATHERS
-        inline SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             __m128i t0 = _mm_load_si128((__m128i*)indices);
             mVec = _mm_i32gather_ps((const float *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t const * indices) {
             __m128i t0 = _mm_load_si128((__m128i*)indices);
             __m128 t1 = _mm_i32gather_ps((const float *)baseAddr, t0, 4);
             mVec = BLEND(mVec, t1, mask.mMask);

--- a/plugins/avx2/float/UMESimdVecFloat32_8.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_8.h
@@ -1105,13 +1105,13 @@ namespace SIMD {
         // MIMIN
 
         // GATHERS
-        inline SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_ps((const float *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256 t1 = _mm256_i32gather_ps((const float *)baseAddr, t0, 4);
             mVec = BLEND(mVec, t1, mask.mMask);

--- a/plugins/avx2/float/UMESimdVecFloat32_8.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_8.h
@@ -1105,25 +1105,25 @@ namespace SIMD {
         // MIMIN
 
         // GATHERS
-        inline SIMDVec_f & gather(float* baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_ps((const float *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<8> const & mask, float* baseAddr, uint32_t* indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256 t1 = _mm256_i32gather_ps((const float *)baseAddr, t0, 4);
             mVec = BLEND(mVec, t1, mask.mMask);
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(float* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        inline SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             mVec = _mm256_i32gather_ps((const float *)baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<8> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             __m256 t0 = _mm256_i32gather_ps((const float *)baseAddr, indices.mVec, 4);
             mVec = BLEND(mVec, t0, mask.mMask);
             return *this;

--- a/plugins/avx2/float/UMESimdVecFloat64_1.h
+++ b/plugins/avx2/float/UMESimdVecFloat64_1.h
@@ -887,22 +887,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(double * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, uint64_t * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, uint64_t * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(double * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx2/float/UMESimdVecFloat64_1.h
+++ b/plugins/avx2/float/UMESimdVecFloat64_1.h
@@ -887,12 +887,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(double const * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, uint64_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx2/float/UMESimdVecFloat64_2.h
+++ b/plugins/avx2/float/UMESimdVecFloat64_2.h
@@ -1045,13 +1045,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(double const * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx2/float/UMESimdVecFloat64_2.h
+++ b/plugins/avx2/float/UMESimdVecFloat64_2.h
@@ -1045,25 +1045,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_f & gather(double * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, uint64_t * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double * baseAddr, uint64_t * indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_f & gather(double * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(double const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double * baseAddr, VEC_UINT_TYPE const & indices) {
+        inline SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx2/int/UMESimdVecInt32_1.h
+++ b/plugins/avx2/int/UMESimdVecInt32_1.h
@@ -1274,22 +1274,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
+        inline SIMDVec_i gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i gather(SIMDVecMask<1> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
+        inline SIMDVec_i gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx2/int/UMESimdVecInt32_1.h
+++ b/plugins/avx2/int/UMESimdVecInt32_1.h
@@ -1274,12 +1274,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx2/int/UMESimdVecInt32_16.h
+++ b/plugins/avx2/int/UMESimdVecInt32_16.h
@@ -1602,7 +1602,7 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec[0] = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             __m256i t1 = _mm256_loadu_si256((__m256i*)(indices + 8));
@@ -1610,7 +1610,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256i t1 = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             mVec[0] = _mm256_blendv_epi8(mVec[0], t1, mask.mMask[0]);

--- a/plugins/avx2/int/UMESimdVecInt32_16.h
+++ b/plugins/avx2/int/UMESimdVecInt32_16.h
@@ -1602,7 +1602,7 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_i & gather(int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec[0] = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             __m256i t1 = _mm256_loadu_si256((__m256i*)(indices + 8));
@@ -1610,7 +1610,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256i t1 = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             mVec[0] = _mm256_blendv_epi8(mVec[0], t1, mask.mMask[0]);
@@ -1620,13 +1620,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i & gather(int32_t* baseAddr, SIMDVec_i const & indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_i const & indices) {
             mVec[0] = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec[0], 4);
             mVec[1] = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec[1], 4);
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t* baseAddr, SIMDVec_i const & indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t const * baseAddr, SIMDVec_i const & indices) {
             __m256i t0 = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec[0], 4);
             mVec[0] = _mm256_blendv_epi8(mVec[0], t0, mask.mMask[0]);
             __m256i t1 = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec[1], 4);

--- a/plugins/avx2/int/UMESimdVecInt32_2.h
+++ b/plugins/avx2/int/UMESimdVecInt32_2.h
@@ -1488,13 +1488,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx2/int/UMESimdVecInt32_2.h
+++ b/plugins/avx2/int/UMESimdVecInt32_2.h
@@ -1488,25 +1488,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
+        inline SIMDVec_i gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
+        inline SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx2/int/UMESimdVecInt32_4.h
+++ b/plugins/avx2/int/UMESimdVecInt32_4.h
@@ -1173,20 +1173,20 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             alignas(16) int32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             mVec = _mm_load_si128((__m128i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             alignas(16) int32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             __m128i t0 = _mm_load_si128((__m128i*)raw);
             mVec = _mm_blendv_epi8(mVec, t0, mask.mMask);
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i & gather(int32_t* baseAddr, SIMDVec_i const & indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_i const & indices) {
             alignas(16) int32_t rawInd[4];
             alignas(16) int32_t raw[4];
 
@@ -1196,7 +1196,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t* baseAddr, SIMDVec_i const & indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, SIMDVec_i const & indices) {
             alignas(16) int32_t rawInd[4];
             alignas(16) int32_t raw[4];
 

--- a/plugins/avx2/int/UMESimdVecInt32_4.h
+++ b/plugins/avx2/int/UMESimdVecInt32_4.h
@@ -1173,13 +1173,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             alignas(16) int32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             mVec = _mm_load_si128((__m128i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             alignas(16) int32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             __m128i t0 = _mm_load_si128((__m128i*)raw);
             mVec = _mm_blendv_epi8(mVec, t0, mask.mMask);

--- a/plugins/avx2/int/UMESimdVecInt32_8.h
+++ b/plugins/avx2/int/UMESimdVecInt32_8.h
@@ -1387,13 +1387,13 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256i t1 = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             mVec = _mm256_blendv_epi8(mVec, t1, mask.mMask);

--- a/plugins/avx2/int/UMESimdVecInt32_8.h
+++ b/plugins/avx2/int/UMESimdVecInt32_8.h
@@ -1387,25 +1387,25 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_i & gather(int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256i t1 = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             mVec = _mm256_blendv_epi8(mVec, t1, mask.mMask);
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i & gather(int32_t* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        inline SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             mVec = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             __m256i t0 = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec, 4);
             mVec = _mm256_blendv_epi8(mVec, t0, mask.mMask);
             return *this;

--- a/plugins/avx2/int/UMESimdVecInt64_1.h
+++ b/plugins/avx2/int/UMESimdVecInt64_1.h
@@ -1273,12 +1273,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx2/int/UMESimdVecInt64_1.h
+++ b/plugins/avx2/int/UMESimdVecInt64_1.h
@@ -1273,22 +1273,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int64_t * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t* baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, uint64_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i gather(int64_t * baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
+        inline SIMDVec_i gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i gather(SIMDVecMask<1> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
+        inline SIMDVec_i gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx2/int/UMESimdVecInt64_2.h
+++ b/plugins/avx2/int/UMESimdVecInt64_2.h
@@ -1487,13 +1487,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx2/int/UMESimdVecInt64_2.h
+++ b/plugins/avx2/int/UMESimdVecInt64_2.h
@@ -1487,25 +1487,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_i & gather(int64_t * baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t* baseAddr, uint64_t* indices) {
+        inline SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_i gather(int64_t * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
+        inline SIMDVec_i gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_i gather(SIMDVecMask<2> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
+        inline SIMDVec_i gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx2/uint/UMESimdVecUint32_1.h
+++ b/plugins/avx2/uint/UMESimdVecUint32_1.h
@@ -1170,12 +1170,12 @@ namespace SIMD {
         }
 
         // GATHER
-        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx2/uint/UMESimdVecUint32_1.h
+++ b/plugins/avx2/uint/UMESimdVecUint32_1.h
@@ -1170,22 +1170,22 @@ namespace SIMD {
         }
 
         // GATHER
-        inline SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u gather(SIMDVecMask<1> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx2/uint/UMESimdVecUint32_16.h
+++ b/plugins/avx2/uint/UMESimdVecUint32_16.h
@@ -1588,7 +1588,7 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec[0] = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             __m256i t1 = _mm256_loadu_si256((__m256i*)(indices + 8));
@@ -1596,7 +1596,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256i t1 = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             mVec[0] = _mm256_blendv_epi8(mVec[0], t1, mask.mMask[0]);

--- a/plugins/avx2/uint/UMESimdVecUint32_16.h
+++ b/plugins/avx2/uint/UMESimdVecUint32_16.h
@@ -1588,7 +1588,7 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec[0] = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             __m256i t1 = _mm256_loadu_si256((__m256i*)(indices + 8));
@@ -1596,7 +1596,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256i t1 = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             mVec[0] = _mm256_blendv_epi8(mVec[0], t1, mask.mMask[0]);
@@ -1606,13 +1606,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u & gather(uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec[0], 4);
             mVec[1] = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec[1], 4);
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             __m256i t0 = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec[0], 4);
             mVec[0] = _mm256_blendv_epi8(mVec[0], t0, mask.mMask[0]);
             __m256i t1 = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec[1], 4);

--- a/plugins/avx2/uint/UMESimdVecUint32_2.h
+++ b/plugins/avx2/uint/UMESimdVecUint32_2.h
@@ -1387,25 +1387,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u & gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx2/uint/UMESimdVecUint32_2.h
+++ b/plugins/avx2/uint/UMESimdVecUint32_2.h
@@ -1387,13 +1387,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx2/uint/UMESimdVecUint32_4.h
+++ b/plugins/avx2/uint/UMESimdVecUint32_4.h
@@ -1178,13 +1178,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             alignas(16) uint32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             mVec = _mm_load_si128((__m128i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             alignas(16) uint32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             __m128i t0 = _mm_load_si128((__m128i*)raw);
             mVec = _mm_blendv_epi8(mVec, t0, mask.mMask);

--- a/plugins/avx2/uint/UMESimdVecUint32_4.h
+++ b/plugins/avx2/uint/UMESimdVecUint32_4.h
@@ -1178,20 +1178,20 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             alignas(16) uint32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             mVec = _mm_load_si128((__m128i*)raw);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             alignas(16) uint32_t raw[4] = { baseAddr[indices[0]], baseAddr[indices[1]], baseAddr[indices[2]], baseAddr[indices[3]] };
             __m128i t0 = _mm_load_si128((__m128i*)raw);
             mVec = _mm_blendv_epi8(mVec, t0, mask.mMask);
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u & gather(uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             alignas(16) uint32_t rawInd[4];
             alignas(16) uint32_t raw[4];
 
@@ -1201,7 +1201,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             alignas(16) uint32_t rawInd[4];
             alignas(16) uint32_t raw[4];
 

--- a/plugins/avx2/uint/UMESimdVecUint32_8.h
+++ b/plugins/avx2/uint/UMESimdVecUint32_8.h
@@ -1343,25 +1343,25 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256i t1 = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             mVec = _mm256_blendv_epi8(mVec, t1, mask.mMask);
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u & gather(uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             __m256i t0 = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec, 4);
             mVec = _mm256_blendv_epi8(mVec, t0, mask.mMask);
             return *this;

--- a/plugins/avx2/uint/UMESimdVecUint32_8.h
+++ b/plugins/avx2/uint/UMESimdVecUint32_8.h
@@ -1343,13 +1343,13 @@ namespace SIMD {
             return retval ^ b;
         }
         // GATHERS
-        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             __m256i t1 = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             mVec = _mm256_blendv_epi8(mVec, t1, mask.mMask);

--- a/plugins/avx2/uint/UMESimdVecUint64_1.h
+++ b/plugins/avx2/uint/UMESimdVecUint64_1.h
@@ -1170,22 +1170,22 @@ namespace SIMD {
         }
 
         // GATHER
-        inline SIMDVec_u & gather(uint64_t * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t* baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u gather(uint64_t * baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u gather(SIMDVecMask<1> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx2/uint/UMESimdVecUint64_1.h
+++ b/plugins/avx2/uint/UMESimdVecUint64_1.h
@@ -1170,12 +1170,12 @@ namespace SIMD {
         }
 
         // GATHER
-        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx2/uint/UMESimdVecUint64_2.h
+++ b/plugins/avx2/uint/UMESimdVecUint64_2.h
@@ -1387,25 +1387,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint64_t * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t* baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        inline SIMDVec_u & gather(uint64_t * baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx2/uint/UMESimdVecUint64_2.h
+++ b/plugins/avx2/uint/UMESimdVecUint64_2.h
@@ -1387,13 +1387,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
+        inline SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx2/uint/UMESimdVecUint64_4.h
+++ b/plugins/avx2/uint/UMESimdVecUint64_4.h
@@ -1720,13 +1720,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 =_mm256_loadu_si256((__m256i *)indices);
             mVec = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
             __m256i t1 = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)

--- a/plugins/avx2/uint/UMESimdVecUint64_4.h
+++ b/plugins/avx2/uint/UMESimdVecUint64_4.h
@@ -1687,7 +1687,7 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m256i t0 = SET1_EPI64(stride);
             __m256i t1 = _mm256_setr_epi64x(0, 1, 2, 3);
@@ -1699,7 +1699,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<4> const & mask, uint64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, uint64_t stride) {
 #if defined(__AVX512DQ__)
             __m256i t0 = SET1_EPI64(stride);
             __m256i t1 = _mm256_setr_epi64x(0, 1, 2, 3);
@@ -1720,13 +1720,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
             __m256i t0 =_mm256_loadu_si256((__m256i *)indices);
             mVec = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
             __m256i t1 = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)
@@ -1741,12 +1741,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = _mm256_i64gather_epi64((__int64 const*)baseAddr, indices.mVec, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             __m256i t0 = _mm256_i64gather_epi64((__int64 const*)baseAddr, indices.mVec, 8);
 #if defined(__AVX512VL__)
             mVec = _mm256_mask_mov_epi64(mVec, mask.mMask, t0);

--- a/plugins/avx512/float/UMESimdVecFloat32_1.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_1.h
@@ -935,32 +935,32 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(float const * baseAddr, uint32_t stride) {
             mVec = baseAddr[0];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<1> const & mask, float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t stride) {
             if (mask.mMask == true) mVec = baseAddr[0];
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx512/float/UMESimdVecFloat32_1.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_1.h
@@ -945,12 +945,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx512/float/UMESimdVecFloat32_16.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_16.h
@@ -998,13 +998,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_i32gather_ps(t0, baseAddr, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, float const * baseAddr, uint32_t const * indices) {
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_mask_i32gather_ps(mVec, m0, t0, baseAddr, 4);

--- a/plugins/avx512/float/UMESimdVecFloat32_16.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_16.h
@@ -982,7 +982,7 @@ namespace SIMD {
         // IMIN
         // MIMIN
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(float const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_mullo_epi32(t0, t1);
@@ -990,7 +990,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<16> const & mask, float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<16> const & mask, float const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_mullo_epi32(t0, t1);
@@ -998,25 +998,25 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_i32gather_ps(t0, baseAddr, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, float const * baseAddr, uint32_t* indices) {
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_mask_i32gather_ps(mVec, m0, t0, baseAddr, 4);
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float* baseAddr, SIMDVec_u<uint32_t, 16> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 16> const & indices) {
             mVec = _mm512_i32gather_ps(indices.mVec, baseAddr, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 16> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 16> const & indices) {
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             mVec = _mm512_mask_i32gather_ps(mVec, m0, indices.mVec, baseAddr, 4);
             return *this;

--- a/plugins/avx512/float/UMESimdVecFloat32_2.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_2.h
@@ -1121,13 +1121,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t const * indices) {
             if ((mask.mMask & 0x1) != 0) mVec[0] = baseAddr[indices[0]];
             if ((mask.mMask & 0x2) != 0) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx512/float/UMESimdVecFloat32_2.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_2.h
@@ -1109,37 +1109,37 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(float const * baseAddr, uint32_t stride) {
             mVec[0] = baseAddr[0];
             mVec[1] = baseAddr[stride];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<2> const & mask, float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t stride) {
             if ((mask.mMask & 0x01) != 0) mVec[0] = baseAddr[0];
             if ((mask.mMask & 0x02) != 0) mVec[1] = baseAddr[stride];
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t * indices) {
             if ((mask.mMask & 0x1) != 0) mVec[0] = baseAddr[indices[0]];
             if ((mask.mMask & 0x2) != 0) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
             if ((mask.mMask & 0x1) != 0) mVec[0] = baseAddr[indices.mVec[0]];
             if ((mask.mMask & 0x2) != 0) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx512/float/UMESimdVecFloat32_32.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_32.h
@@ -1316,7 +1316,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices + 16);
             mVec[0] = _mm512_i32gather_ps(t0, baseAddr, 4);
@@ -1324,7 +1324,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<32> const & mask, float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<32> const & mask, float const * baseAddr, uint32_t const * indices) {
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             __mmask16 m1 = (mask.mMask & 0xFFFF0000) >> 16;
             __m512i t0 = _mm512_loadu_si512(indices);

--- a/plugins/avx512/float/UMESimdVecFloat32_32.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_32.h
@@ -1294,7 +1294,7 @@ namespace SIMD {
         // IMIN
         // MIMIN
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(float const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_setr_epi32(16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -1305,7 +1305,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<32> const & mask, float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<32> const & mask, float const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_setr_epi32(16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -1316,7 +1316,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices + 16);
             mVec[0] = _mm512_i32gather_ps(t0, baseAddr, 4);
@@ -1324,7 +1324,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<32> const & mask, float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<32> const & mask, float const * baseAddr, uint32_t* indices) {
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             __mmask16 m1 = (mask.mMask & 0xFFFF0000) >> 16;
             __m512i t0 = _mm512_loadu_si512(indices);
@@ -1334,13 +1334,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float* baseAddr, SIMDVec_u<uint32_t, 32> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 32> const & indices) {
             mVec[0] = _mm512_i32gather_ps(indices.mVec[0], baseAddr, 4);
             mVec[1] = _mm512_i32gather_ps(indices.mVec[1], baseAddr, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<32> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 32> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<32> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 32> const & indices) {
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             __mmask16 m1 = (mask.mMask & 0xFFFF0000) >> 16;
             mVec[0] = _mm512_mask_i32gather_ps(mVec[0], m0, indices.mVec[0], baseAddr, 4);

--- a/plugins/avx512/float/UMESimdVecFloat32_4.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_4.h
@@ -1492,7 +1492,7 @@ namespace SIMD {
         // MIMIN
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(float const * baseAddr, uint32_t stride) {
             __m128i t0 = _mm_set1_epi32(stride);
             __m128i t1 = _mm_setr_epi32(0, 1, 2, 3);
             __m128i t2 = _mm_mullo_epi32(t0, t1);
@@ -1500,7 +1500,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<4> const & mask, float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t stride) {
             __m128i t0 = _mm_set1_epi32(stride);
             __m128i t1 = _mm_setr_epi32(0, 1, 2, 3);
             __m128i t2 = _mm_mullo_epi32(t0, t1);
@@ -1515,13 +1515,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
             mVec = _mm_i32gather_ps(baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_ps(mVec, mask.mMask, t0, baseAddr, 4);
@@ -1534,12 +1534,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float* baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
             mVec = _mm_i32gather_ps(baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_ps(mVec, mask.mMask, indices.mVec, baseAddr, 4);
 #else

--- a/plugins/avx512/float/UMESimdVecFloat32_4.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_4.h
@@ -1515,13 +1515,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
             mVec = _mm_i32gather_ps(baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_ps(mVec, mask.mMask, t0, baseAddr, 4);

--- a/plugins/avx512/float/UMESimdVecFloat32_8.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_8.h
@@ -1491,7 +1491,7 @@ namespace SIMD {
         // IMIN
         // MIMIN
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(float const * baseAddr, uint32_t stride) {
             __m256i t0 = _mm256_set1_epi32(stride);
             __m256i t1 = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
             __m256i t2 = _mm256_mullo_epi32(t0, t1);
@@ -1499,7 +1499,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<8> const & mask, float * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t stride) {
             __m256i t0 = _mm256_set1_epi32(stride);
             __m256i t1 = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
             __m256i t2 = _mm256_mullo_epi32(t0, t1);
@@ -1514,13 +1514,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_ps(baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm256_mmask_i32gather_ps(mVec, mask.mMask, t0, baseAddr, 4);
@@ -1533,12 +1533,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             mVec = _mm256_i32gather_ps(baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
 #if defined(__AVX512VL__)
             mVec = _mm256_mmask_i32gather_ps(mVec, mask.mMask, indices.mVec, baseAddr, 4);
 #else

--- a/plugins/avx512/float/UMESimdVecFloat32_8.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_8.h
@@ -1514,13 +1514,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_ps(baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm256_mmask_i32gather_ps(mVec, mask.mMask, t0, baseAddr, 4);

--- a/plugins/avx512/float/UMESimdVecFloat64_1.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_1.h
@@ -953,12 +953,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, uint64_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, uint64_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx512/float/UMESimdVecFloat64_1.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_1.h
@@ -943,32 +943,32 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(double * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(double const * baseAddr, uint64_t stride) {
             mVec = baseAddr[0];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<1> const & mask, double * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<1> const & mask, double const * baseAddr, uint64_t stride) {
             if (mask.mMask == true) mVec = baseAddr[0];
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double * baseAddr, uint64_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, double * baseAddr, uint64_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, uint64_t * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(double * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, double * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, double const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx512/float/UMESimdVecFloat64_16.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_16.h
@@ -1165,7 +1165,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices + 8);
             mVec[0] = _mm512_i64gather_pd(t0, baseAddr, 8);
@@ -1173,7 +1173,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, double const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, double const * baseAddr, uint64_t const * indices) {
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
             __m512i t0 = _mm512_loadu_si512(indices);

--- a/plugins/avx512/float/UMESimdVecFloat64_16.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_16.h
@@ -1131,7 +1131,7 @@ namespace SIMD {
         // MIMIN
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(double * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(double const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -1147,7 +1147,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<16> const & mask, double* baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<16> const & mask, double const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -1165,7 +1165,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices + 8);
             mVec[0] = _mm512_i64gather_pd(t0, baseAddr, 8);
@@ -1173,7 +1173,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, double* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, double const * baseAddr, uint64_t* indices) {
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
             __m512i t0 = _mm512_loadu_si512(indices);
@@ -1183,13 +1183,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(double* baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
             mVec[0] = _mm512_i64gather_pd(indices.mVec[0], baseAddr, 8);
             mVec[1] = _mm512_i64gather_pd(indices.mVec[1], baseAddr, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, double* baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<16> const & mask, double const * baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
             mVec[0] = _mm512_mask_i64gather_pd(mVec[0], m0, indices.mVec[0], baseAddr, 8);

--- a/plugins/avx512/float/UMESimdVecFloat64_2.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_2.h
@@ -1431,13 +1431,13 @@ namespace SIMD {
         // MIMIN
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(double * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(double const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
             mVec = _mm_i64gather_pd(baseAddr, t0, 8);
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<2> const & mask, double * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i64gather_pd(mVec, mask.mMask, t0, baseAddr, 8);
@@ -1450,13 +1450,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
             mVec = _mm_i64gather_pd(baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, double* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i64gather_pd(mVec, mask.mMask, t0, baseAddr, 8);
@@ -1469,12 +1469,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(double* baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
             mVec = _mm_i64gather_pd(baseAddr, indices.mVec, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, double* baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i64gather_pd(mVec, mask.mMask, indices.mVec, baseAddr, 8);
 #else

--- a/plugins/avx512/float/UMESimdVecFloat64_2.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_2.h
@@ -1450,13 +1450,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
             mVec = _mm_i64gather_pd(baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i64gather_pd(mVec, mask.mMask, t0, baseAddr, 8);

--- a/plugins/avx512/float/UMESimdVecFloat64_4.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_4.h
@@ -1429,7 +1429,7 @@ namespace SIMD {
         // MIMIN
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(double * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(double const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m256i t0 = _mm256_set1_epi64x(stride);
             __m256i t1 = _mm256_setr_epi64x(0, 1, 2, 3);
@@ -1441,7 +1441,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<4> const & mask, double* baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<4> const & mask, double const * baseAddr, uint64_t stride) {
 #if defined(__AVX512DQ__)
             __m256i t0 = _mm256_set1_epi64x(stride);
             __m256i t1 = _mm256_setr_epi64x(0, 1, 2, 3);
@@ -1460,13 +1460,13 @@ namespace SIMD {
             return *this;
         }
         //GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i64gather_pd(baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, double* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, double const * baseAddr, uint64_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm256_mmask_i64gather_pd(mVec, mask.mMask, t0, baseAddr, 8);
@@ -1479,12 +1479,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(double* baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
             mVec = _mm256_i64gather_pd(baseAddr, indices.mVec, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, double* baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, double const * baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
 #if defined(__AVX512VL__)
             mVec = _mm256_mmask_i64gather_pd(mVec, mask.mMask, indices.mVec, baseAddr, 8);
 #else

--- a/plugins/avx512/float/UMESimdVecFloat64_4.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_4.h
@@ -1460,13 +1460,13 @@ namespace SIMD {
             return *this;
         }
         //GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i64gather_pd(baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, double const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, double const * baseAddr, uint64_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm256_mmask_i64gather_pd(mVec, mask.mMask, t0, baseAddr, 8);

--- a/plugins/avx512/float/UMESimdVecFloat64_8.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_8.h
@@ -995,13 +995,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_i64gather_pd(t0, baseAddr, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, double const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, double const * baseAddr, uint64_t const * indices) {
             __mmask8 m0 = mask.mMask & 0xFF;
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_mask_i64gather_pd(mVec, m0, t0, baseAddr, 8);

--- a/plugins/avx512/float/UMESimdVecFloat64_8.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_8.h
@@ -970,7 +970,7 @@ namespace SIMD {
         // MIMIN
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(double * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(double const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -982,7 +982,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<8> const & mask, double* baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_f & gatheru(SIMDVecMask<8> const & mask, double const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -995,25 +995,25 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_i64gather_pd(t0, baseAddr, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, double* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, double const * baseAddr, uint64_t* indices) {
             __mmask8 m0 = mask.mMask & 0xFF;
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_mask_i64gather_pd(mVec, m0, t0, baseAddr, 8);
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(double* baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
             mVec = _mm512_i64gather_pd(indices.mVec, baseAddr, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, double* baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, double const * baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
             __mmask8 m0 = mask.mMask & 0xFF;
             mVec = _mm512_mask_i64gather_pd(mVec, m0, indices.mVec, baseAddr, 8);
             return *this;

--- a/plugins/avx512/int/UMESimdVecInt32_1.h
+++ b/plugins/avx512/int/UMESimdVecInt32_1.h
@@ -1274,32 +1274,32 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t const * baseAddr, uint32_t stride) {
             mVec = baseAddr[0];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<1> const & mask, int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t stride) {
             if (mask.mMask == true) mVec = baseAddr[0];
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<1> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx512/int/UMESimdVecInt32_1.h
+++ b/plugins/avx512/int/UMESimdVecInt32_1.h
@@ -1284,12 +1284,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx512/int/UMESimdVecInt32_16.h
+++ b/plugins/avx512/int/UMESimdVecInt32_16.h
@@ -1159,7 +1159,7 @@ namespace SIMD {
             return t0;
         }
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_mullo_epi32(t0, t1);
@@ -1167,7 +1167,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<16> const & mask, int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<16> const & mask, int32_t const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_mullo_epi32(t0, t1);
@@ -1175,24 +1175,24 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_i32gather_epi32(t0, baseAddr, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_mask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t* baseAddr, SIMDVec_i const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_i const & indices) {
             mVec = _mm512_i32gather_epi32(indices.mVec, baseAddr, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t* baseAddr, SIMDVec_i const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t const * baseAddr, SIMDVec_i const & indices) {
             mVec = _mm512_mask_i32gather_epi32(mVec, mask.mMask, indices.mVec, baseAddr, 4);
             return *this;
         }

--- a/plugins/avx512/int/UMESimdVecInt32_16.h
+++ b/plugins/avx512/int/UMESimdVecInt32_16.h
@@ -1175,13 +1175,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_i32gather_epi32(t0, baseAddr, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_mask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);
             return *this;

--- a/plugins/avx512/int/UMESimdVecInt32_2.h
+++ b/plugins/avx512/int/UMESimdVecInt32_2.h
@@ -1500,13 +1500,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (((mask.mMask & 0x1) != 0)) mVec[0] = baseAddr[indices[0]];
             if (((mask.mMask & 0x2) != 0)) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx512/int/UMESimdVecInt32_2.h
+++ b/plugins/avx512/int/UMESimdVecInt32_2.h
@@ -1488,37 +1488,37 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t const * baseAddr, uint32_t stride) {
             mVec[0] = baseAddr[0];
             mVec[1] = baseAddr[stride];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<2> const & mask, int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t stride) {
             if ((mask.mMask & 0x01) != 0) mVec[0] = baseAddr[0];
             if ((mask.mMask & 0x02) != 0) mVec[1] = baseAddr[stride];
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (((mask.mMask & 0x1) != 0)) mVec[0] = baseAddr[indices[0]];
             if (((mask.mMask & 0x2) != 0)) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
             if (((mask.mMask & 0x1) != 0)) mVec[0] = baseAddr[indices.mVec[0]];
             if (((mask.mMask & 0x2) != 0)) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx512/int/UMESimdVecInt32_32.h
+++ b/plugins/avx512/int/UMESimdVecInt32_32.h
@@ -1484,7 +1484,7 @@ namespace SIMD {
             return t0;
         }
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_setr_epi32(16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -1495,7 +1495,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<32> const & mask, int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<32> const & mask, int32_t const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_setr_epi32(16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -1506,7 +1506,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices+16);
             mVec[0] = _mm512_i32gather_epi32(t0, baseAddr, 4);
@@ -1514,7 +1514,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<32> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<32> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices+16);
             mVec[0] = _mm512_mask_i32gather_epi32(mVec[0], mask.mMask & 0x0000FFFF, t0, baseAddr, 4);
@@ -1522,13 +1522,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t* baseAddr, SIMDVec_u<uint32_t, 32> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 32> const & indices) {
             mVec[0] = _mm512_i32gather_epi32(indices.mVec[0], baseAddr, 4);
             mVec[1] = _mm512_i32gather_epi32(indices.mVec[1], baseAddr, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<32> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 32> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<32> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 32> const & indices) {
             mVec[0] = _mm512_mask_i32gather_epi32(mVec[0], mask.mMask & 0x0000FFFF, indices.mVec[0], baseAddr, 4);
             mVec[1] = _mm512_mask_i32gather_epi32(mVec[1], (mask.mMask & 0xFFFF0000) >> 16, indices.mVec[1], baseAddr, 4);
             return *this;

--- a/plugins/avx512/int/UMESimdVecInt32_32.h
+++ b/plugins/avx512/int/UMESimdVecInt32_32.h
@@ -1506,7 +1506,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices+16);
             mVec[0] = _mm512_i32gather_epi32(t0, baseAddr, 4);
@@ -1514,7 +1514,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<32> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<32> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices+16);
             mVec[0] = _mm512_mask_i32gather_epi32(mVec[0], mask.mMask & 0x0000FFFF, t0, baseAddr, 4);

--- a/plugins/avx512/int/UMESimdVecInt32_4.h
+++ b/plugins/avx512/int/UMESimdVecInt32_4.h
@@ -1695,13 +1695,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
             mVec = _mm_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);

--- a/plugins/avx512/int/UMESimdVecInt32_4.h
+++ b/plugins/avx512/int/UMESimdVecInt32_4.h
@@ -1672,7 +1672,7 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t const * baseAddr, uint32_t stride) {
             __m128i t0 = _mm_set1_epi32(stride);
             __m128i t1 = _mm_setr_epi32(0, 1, 2, 3);
             __m128i t2 = _mm_mullo_epi32(t0, t1);
@@ -1680,7 +1680,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<4> const & mask, int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t stride) {
             __m128i t0 = _mm_set1_epi32(stride);
             __m128i t1 = _mm_setr_epi32(0, 1, 2, 3);
             __m128i t2 = _mm_mullo_epi32(t0, t1);
@@ -1695,13 +1695,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
             mVec = _mm_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);
@@ -1714,12 +1714,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t* baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
             mVec = _mm_i32gather_epi32((const int *)baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_epi32(mVec, mask.mMask, indices.mVec, baseAddr, 4);
 #else

--- a/plugins/avx512/int/UMESimdVecInt32_8.h
+++ b/plugins/avx512/int/UMESimdVecInt32_8.h
@@ -1689,13 +1689,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_epi32((const int *) baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
 #if defined(__AVX512VL__)
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_mmask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);

--- a/plugins/avx512/int/UMESimdVecInt32_8.h
+++ b/plugins/avx512/int/UMESimdVecInt32_8.h
@@ -1666,7 +1666,7 @@ namespace SIMD {
             return t0;
         }
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int32_t const * baseAddr, uint32_t stride) {
             __m256i t0 = _mm256_set1_epi32(stride);
             __m256i t1 = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
             __m256i t2 = _mm256_mullo_epi32(t0, t1);
@@ -1674,7 +1674,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<8> const & mask, int32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t stride) {
             __m256i t0 = _mm256_set1_epi32(stride);
             __m256i t1 = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
             __m256i t2 = _mm256_mullo_epi32(t0, t1);
@@ -1689,13 +1689,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_epi32((const int *) baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t* indices) {
 #if defined(__AVX512VL__)
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_mmask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);
@@ -1710,12 +1710,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t* baseAddr, SIMDVec_i const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_i const & indices) {
             mVec = _mm256_i32gather_epi32((const int *) baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t* baseAddr, SIMDVec_i const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, SIMDVec_i const & indices) {
 #if defined(__AVX512VL__)
             mVec = _mm256_mmask_i32gather_epi32(mVec, mask.mMask, indices.mVec, baseAddr, 4);
 #else

--- a/plugins/avx512/int/UMESimdVecInt64_1.h
+++ b/plugins/avx512/int/UMESimdVecInt64_1.h
@@ -1283,12 +1283,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx512/int/UMESimdVecInt64_1.h
+++ b/plugins/avx512/int/UMESimdVecInt64_1.h
@@ -1273,32 +1273,32 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t const * baseAddr, uint64_t stride) {
             mVec = baseAddr[0];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<1> const & mask, int64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<1> const & mask, int64_t const * baseAddr, uint64_t stride) {
             if (mask.mMask == true) mVec = baseAddr[0];
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, uint64_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(int64_t * baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<1> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<1> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 1> const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx512/int/UMESimdVecInt64_16.h
+++ b/plugins/avx512/int/UMESimdVecInt64_16.h
@@ -2035,7 +2035,7 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -2051,7 +2051,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<16> const & mask, int64_t* baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<16> const & mask, int64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -2069,7 +2069,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
             mVec[0] = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
@@ -2077,7 +2077,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int64_t const * baseAddr, uint64_t* indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
             __m512i t2 = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
@@ -2087,13 +2087,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t * baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
             mVec[0] = _mm512_i64gather_epi64(indices.mVec[0], (__int64 const*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(indices.mVec[1], (__int64 const*)baseAddr, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
             __m512i t0 = _mm512_i64gather_epi64(indices.mVec[0], (__int64 const*)baseAddr, 8);
             __m512i t1 = _mm512_i64gather_epi64(indices.mVec[1], (__int64 const*)baseAddr, 8);
             mVec[0] = _mm512_mask_mov_epi64(mVec[0], mask.mMask & 0xFF, t0);

--- a/plugins/avx512/int/UMESimdVecInt64_16.h
+++ b/plugins/avx512/int/UMESimdVecInt64_16.h
@@ -2069,7 +2069,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
             mVec[0] = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
@@ -2077,7 +2077,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
             __m512i t2 = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);

--- a/plugins/avx512/int/UMESimdVecInt64_2.h
+++ b/plugins/avx512/int/UMESimdVecInt64_2.h
@@ -1667,13 +1667,13 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
             mVec = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<2> const & mask, int64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
             __m128i t1 = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)
@@ -1688,13 +1688,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
             __m128i t0 =_mm_loadu_si128((__m128i *)indices);
             mVec = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
             __m128i t1 = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)
@@ -1709,12 +1709,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
             mVec = _mm_i64gather_epi64((__int64 const*)baseAddr, indices.mVec, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
             __m128i t0 = _mm_i64gather_epi64((__int64 const*)baseAddr, indices.mVec, 8);
 #if defined(__AVX512VL__)
             mVec = _mm_mask_mov_epi64(mVec, mask.mMask, t0);

--- a/plugins/avx512/int/UMESimdVecInt64_2.h
+++ b/plugins/avx512/int/UMESimdVecInt64_2.h
@@ -1688,13 +1688,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 =_mm_loadu_si128((__m128i *)indices);
             mVec = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
             __m128i t1 = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)

--- a/plugins/avx512/int/UMESimdVecInt64_4.h
+++ b/plugins/avx512/int/UMESimdVecInt64_4.h
@@ -1773,13 +1773,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 =_mm256_loadu_si256((__m256i *)indices);
             mVec = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
             __m256i t1 = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)

--- a/plugins/avx512/int/UMESimdVecInt64_4.h
+++ b/plugins/avx512/int/UMESimdVecInt64_4.h
@@ -1740,7 +1740,7 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m256i t0 = SET1_EPI64(stride);
             __m256i t1 = _mm256_setr_epi64x(0, 1, 2, 3);
@@ -1752,7 +1752,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<4> const & mask, int64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<4> const & mask, int64_t const * baseAddr, uint64_t stride) {
 #if defined(__AVX512DQ__)
             __m256i t0 = SET1_EPI64(stride);
             __m256i t1 = _mm256_setr_epi64x(0, 1, 2, 3);
@@ -1773,13 +1773,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
             __m256i t0 =_mm256_loadu_si256((__m256i *)indices);
             mVec = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int64_t const * baseAddr, uint64_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
             __m256i t1 = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)
@@ -1794,12 +1794,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t * baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
             mVec = _mm256_i64gather_epi64((__int64 const*)baseAddr, indices.mVec, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
             __m256i t0 = _mm256_i64gather_epi64((__int64 const*)baseAddr, indices.mVec, 8);
 #if defined(__AVX512VL__)
             mVec = _mm256_mask_mov_epi64(mVec, mask.mMask, t0);

--- a/plugins/avx512/int/UMESimdVecInt64_8.h
+++ b/plugins/avx512/int/UMESimdVecInt64_8.h
@@ -1494,7 +1494,7 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -1506,7 +1506,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<8> const & mask, int64_t* baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<8> const & mask, int64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -1519,25 +1519,25 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
             __m512i t0 =_mm512_loadu_si512((__m512i *)indices);
             mVec = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int64_t const * baseAddr, uint64_t* indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
             mVec = _mm512_mask_mov_epi64(mVec, mask.mMask, t1);
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t * baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
             mVec = _mm512_i64gather_epi64(indices.mVec, (__int64 const*)baseAddr, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
             __m512i t0 = _mm512_i64gather_epi64(indices.mVec, (__int64 const*)baseAddr, 8);
             mVec = _mm512_mask_mov_epi64(mVec, mask.mMask, t0);
             return *this;

--- a/plugins/avx512/int/UMESimdVecInt64_8.h
+++ b/plugins/avx512/int/UMESimdVecInt64_8.h
@@ -1519,13 +1519,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 =_mm512_loadu_si512((__m512i *)indices);
             mVec = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
             mVec = _mm512_mask_mov_epi64(mVec, mask.mMask, t1);

--- a/plugins/avx512/uint/UMESimdVecUint16_1.h
+++ b/plugins/avx512/uint/UMESimdVecUint16_1.h
@@ -1170,32 +1170,32 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint16_t * baseAddr, uint16_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint16_t const * baseAddr, uint16_t stride) {
             mVec = baseAddr[0];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<1> const & mask, uint16_t * baseAddr, uint16_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<1> const & mask, uint16_t const * baseAddr, uint16_t stride) {
             if (mask.mMask == true) mVec = baseAddr[0];
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint16_t * baseAddr, uint16_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint16_t const * baseAddr, uint16_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint16_t* baseAddr, uint16_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint16_t const * baseAddr, uint16_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u gather(uint16_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u gather(uint16_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u gather(SIMDVecMask<1> const & mask, uint16_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u gather(SIMDVecMask<1> const & mask, uint16_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx512/uint/UMESimdVecUint16_1.h
+++ b/plugins/avx512/uint/UMESimdVecUint16_1.h
@@ -1180,12 +1180,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint16_t const * baseAddr, uint16_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint16_t const * baseAddr, uint16_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint16_t const * baseAddr, uint16_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint16_t const * baseAddr, uint16_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx512/uint/UMESimdVecUint16_2.h
+++ b/plugins/avx512/uint/UMESimdVecUint16_2.h
@@ -1387,37 +1387,37 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint16_t * baseAddr, uint16_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint16_t const * baseAddr, uint16_t stride) {
             mVec[0] = baseAddr[0];
             mVec[1] = baseAddr[stride];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<2> const & mask, uint16_t * baseAddr, uint16_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<2> const & mask, uint16_t const * baseAddr, uint16_t stride) {
             if ((mask.mMask & 0x01) != 0) mVec[0] = baseAddr[0];
             if ((mask.mMask & 0x02) != 0) mVec[1] = baseAddr[stride];
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint16_t * baseAddr, uint16_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint16_t const * baseAddr, uint16_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint16_t* baseAddr, uint16_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint16_t const * baseAddr, uint16_t* indices) {
             if ((mask.mMask & 0x01) != 0) mVec[0] = baseAddr[indices[0]];
             if ((mask.mMask & 0x02) != 0) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint16_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint16_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint16_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint16_t const * baseAddr, SIMDVec_u const & indices) {
             if ((mask.mMask & 0x01) != 0) mVec[0] = baseAddr[indices.mVec[0]];
             if ((mask.mMask & 0x02) != 0) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx512/uint/UMESimdVecUint16_2.h
+++ b/plugins/avx512/uint/UMESimdVecUint16_2.h
@@ -1399,13 +1399,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint16_t const * baseAddr, uint16_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint16_t const * baseAddr, uint16_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint16_t const * baseAddr, uint16_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint16_t const * baseAddr, uint16_t const * indices) {
             if ((mask.mMask & 0x01) != 0) mVec[0] = baseAddr[indices[0]];
             if ((mask.mMask & 0x02) != 0) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx512/uint/UMESimdVecUint16_4.h
+++ b/plugins/avx512/uint/UMESimdVecUint16_4.h
@@ -1696,13 +1696,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
             mVec = _mm_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);

--- a/plugins/avx512/uint/UMESimdVecUint16_4.h
+++ b/plugins/avx512/uint/UMESimdVecUint16_4.h
@@ -1673,7 +1673,7 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t const * baseAddr, uint32_t stride) {
             __m128i t0 = _mm_set1_epi32(stride);
             __m128i t1 = _mm_setr_epi32(0, 1, 2, 3);
             __m128i t2 = _mm_mullo_epi32(t0, t1);
@@ -1681,7 +1681,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<4> const & mask, uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t stride) {
             __m128i t0 = _mm_set1_epi32(stride);
             __m128i t1 = _mm_setr_epi32(0, 1, 2, 3);
             __m128i t2 = _mm_mullo_epi32(t0, t1);
@@ -1696,13 +1696,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
             mVec = _mm_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);
@@ -1715,12 +1715,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = _mm_i32gather_epi32((const int *)baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_epi32(mVec, mask.mMask, indices.mVec, baseAddr, 4);
 #else

--- a/plugins/avx512/uint/UMESimdVecUint32_1.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_1.h
@@ -1180,12 +1180,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx512/uint/UMESimdVecUint32_1.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_1.h
@@ -1170,32 +1170,32 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t const * baseAddr, uint32_t stride) {
             mVec = baseAddr[0];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<1> const & mask, uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t stride) {
             if (mask.mMask == true) mVec = baseAddr[0];
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u gather(SIMDVecMask<1> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx512/uint/UMESimdVecUint32_16.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_16.h
@@ -1253,7 +1253,7 @@ namespace SIMD {
             return t0;
         }
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_mullo_epi32(t0, t1);
@@ -1261,7 +1261,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<16> const & mask, uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<16> const & mask, uint32_t const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_mullo_epi32(t0, t1);
@@ -1269,24 +1269,24 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_i32gather_epi32(t0, baseAddr, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_mask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = _mm512_i32gather_epi32(indices.mVec, baseAddr, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = _mm512_mask_i32gather_epi32(mVec, mask.mMask, indices.mVec, baseAddr, 4);
             return *this;
         }

--- a/plugins/avx512/uint/UMESimdVecUint32_16.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_16.h
@@ -1269,13 +1269,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_i32gather_epi32(t0, baseAddr, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             mVec = _mm512_mask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);
             return *this;

--- a/plugins/avx512/uint/UMESimdVecUint32_2.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_2.h
@@ -1387,37 +1387,37 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t const * baseAddr, uint32_t stride) {
             mVec[0] = baseAddr[0];
             mVec[1] = baseAddr[stride];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<2> const & mask, uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t stride) {
             if ((mask.mMask & 0x01) != 0) mVec[0] = baseAddr[0];
             if ((mask.mMask & 0x02) != 0) mVec[1] = baseAddr[stride];
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if ((mask.mMask & 0x01) != 0) mVec[0] = baseAddr[indices[0]];
             if ((mask.mMask & 0x02) != 0) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if ((mask.mMask & 0x01) != 0) mVec[0] = baseAddr[indices.mVec[0]];
             if ((mask.mMask & 0x02) != 0) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/avx512/uint/UMESimdVecUint32_2.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_2.h
@@ -1399,13 +1399,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if ((mask.mMask & 0x01) != 0) mVec[0] = baseAddr[indices[0]];
             if ((mask.mMask & 0x02) != 0) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/avx512/uint/UMESimdVecUint32_32.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_32.h
@@ -1498,7 +1498,7 @@ namespace SIMD {
             return t0;
         }
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_setr_epi32(16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -1509,7 +1509,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<32> const & mask, uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<32> const & mask, uint32_t const * baseAddr, uint32_t stride) {
             __m512i t0 = _mm512_set1_epi32(stride);
             __m512i t1 = _mm512_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
             __m512i t2 = _mm512_setr_epi32(16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31);
@@ -1520,7 +1520,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices+16);
             mVec[0] = _mm512_i32gather_epi32(t0, baseAddr, 4);
@@ -1528,7 +1528,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<32> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<32> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices+16);
             mVec[0] = _mm512_mask_i32gather_epi32(mVec[0], mask.mMask & 0x0000FFFF, t0, baseAddr, 4);
@@ -1536,13 +1536,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = _mm512_i32gather_epi32(indices.mVec[0], baseAddr, 4);
             mVec[1] = _mm512_i32gather_epi32(indices.mVec[1], baseAddr, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<32> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<32> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = _mm512_mask_i32gather_epi32(mVec[0], mask.mMask & 0x0000FFFF, indices.mVec[0], baseAddr, 4);
             mVec[1] = _mm512_mask_i32gather_epi32(mVec[1], (mask.mMask & 0xFFFF0000) >> 16, indices.mVec[1], baseAddr, 4);
             return *this;

--- a/plugins/avx512/uint/UMESimdVecUint32_32.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_32.h
@@ -1520,7 +1520,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices+16);
             mVec[0] = _mm512_i32gather_epi32(t0, baseAddr, 4);
@@ -1528,7 +1528,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<32> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<32> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             __m512i t0 = _mm512_loadu_si512(indices);
             __m512i t1 = _mm512_loadu_si512(indices+16);
             mVec[0] = _mm512_mask_i32gather_epi32(mVec[0], mask.mMask & 0x0000FFFF, t0, baseAddr, 4);

--- a/plugins/avx512/uint/UMESimdVecUint32_4.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_4.h
@@ -1696,13 +1696,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
             mVec = _mm_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);

--- a/plugins/avx512/uint/UMESimdVecUint32_4.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_4.h
@@ -1673,7 +1673,7 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t const * baseAddr, uint32_t stride) {
             __m128i t0 = _mm_set1_epi32(stride);
             __m128i t1 = _mm_setr_epi32(0, 1, 2, 3);
             __m128i t2 = _mm_mullo_epi32(t0, t1);
@@ -1681,7 +1681,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<4> const & mask, uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t stride) {
             __m128i t0 = _mm_set1_epi32(stride);
             __m128i t1 = _mm_setr_epi32(0, 1, 2, 3);
             __m128i t2 = _mm_mullo_epi32(t0, t1);
@@ -1696,13 +1696,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
             mVec = _mm_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i*)indices);
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);
@@ -1715,12 +1715,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = _mm_i32gather_epi32((const int *)baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
 #if defined(__AVX512VL__)
             mVec = _mm_mmask_i32gather_epi32(mVec, mask.mMask, indices.mVec, baseAddr, 4);
 #else

--- a/plugins/avx512/uint/UMESimdVecUint32_8.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_8.h
@@ -1690,7 +1690,7 @@ namespace SIMD {
             return t0;
         }
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint32_t const * baseAddr, uint32_t stride) {
             __m256i t0 = _mm256_set1_epi32(stride);
             __m256i t1 = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
             __m256i t2 = _mm256_mullo_epi32(t0, t1);
@@ -1698,7 +1698,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<8> const & mask, uint32_t * baseAddr, uint32_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t stride) {
             __m256i t0 = _mm256_set1_epi32(stride);
             __m256i t1 = _mm256_setr_epi32(0, 1, 2, 3, 4, 5, 6, 7);
             __m256i t2 = _mm256_mullo_epi32(t0, t1);
@@ -1713,13 +1713,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
 #if defined(__AVX512VL__)
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_mmask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);
@@ -1734,12 +1734,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = _mm256_i32gather_epi32((const int *)baseAddr, indices.mVec, 4);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
 #if defined(__AVX512VL__)
             mVec = _mm256_mmask_i32gather_epi32(mVec, mask.mMask, indices.mVec, baseAddr, 4);
 #else

--- a/plugins/avx512/uint/UMESimdVecUint32_8.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_8.h
@@ -1713,13 +1713,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_i32gather_epi32((const int *)baseAddr, t0, 4);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
 #if defined(__AVX512VL__)
             __m256i t0 = _mm256_loadu_si256((__m256i*)indices);
             mVec = _mm256_mmask_i32gather_epi32(mVec, mask.mMask, t0, baseAddr, 4);

--- a/plugins/avx512/uint/UMESimdVecUint64_1.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_1.h
@@ -1170,32 +1170,32 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t const * baseAddr, uint64_t stride) {
             mVec = baseAddr[0];
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<1> const & mask, uint64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, uint64_t stride) {
             if (mask.mMask == true) mVec = baseAddr[0];
             return *this;
         }
         // GATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u gather(uint64_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u gather(SIMDVecMask<1> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/avx512/uint/UMESimdVecUint64_1.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_1.h
@@ -1180,12 +1180,12 @@ namespace SIMD {
             return *this;
         }
         // GATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/avx512/uint/UMESimdVecUint64_16.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_16.h
@@ -1676,7 +1676,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 =_mm512_loadu_si512((__m512i *)(indices + 8));
             mVec[0] = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
@@ -1684,7 +1684,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __mmask8 t0 = mask.mMask & 0x00FF;
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
             __m512i t2 = _mm512_loadu_si512((__m512i *)indices);

--- a/plugins/avx512/uint/UMESimdVecUint64_16.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_16.h
@@ -1640,7 +1640,7 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -1656,7 +1656,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<16> const & mask, uint64_t* baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<16> const & mask, uint64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -1676,7 +1676,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 =_mm512_loadu_si512((__m512i *)(indices + 8));
             mVec[0] = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
@@ -1684,7 +1684,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
             __mmask8 t0 = mask.mMask & 0x00FF;
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
             __m512i t2 = _mm512_loadu_si512((__m512i *)indices);
@@ -1696,13 +1696,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = _mm512_i64gather_epi64(indices.mVec[0], (__int64 const*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(indices.mVec[1], (__int64 const*)baseAddr, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             __mmask8 t0 = mask.mMask & 0x00FF;
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
             __m512i t2 = _mm512_i64gather_epi64(indices.mVec[0], (__int64 const*)baseAddr, 8);

--- a/plugins/avx512/uint/UMESimdVecUint64_2.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_2.h
@@ -1672,13 +1672,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 =_mm_loadu_si128((__m128i *)indices);
             mVec = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
             __m128i t1 = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)

--- a/plugins/avx512/uint/UMESimdVecUint64_2.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_2.h
@@ -1651,13 +1651,13 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
             mVec = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<2> const & mask, uint64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
             __m128i t1 = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)
@@ -1672,13 +1672,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
             __m128i t0 =_mm_loadu_si128((__m128i *)indices);
             mVec = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
             __m128i t1 = _mm_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)
@@ -1693,12 +1693,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = _mm_i64gather_epi64((__int64 const*)baseAddr, indices.mVec, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             __m128i t0 = _mm_i64gather_epi64((__int64 const*)baseAddr, indices.mVec, 8);
 #if defined(__AVX512VL__)
             mVec = _mm_mask_mov_epi64(mVec, mask.mMask, t0);

--- a/plugins/avx512/uint/UMESimdVecUint64_4.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_4.h
@@ -1759,13 +1759,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 =_mm256_loadu_si256((__m256i *)indices);
             mVec = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
             __m256i t1 = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)

--- a/plugins/avx512/uint/UMESimdVecUint64_4.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_4.h
@@ -1726,7 +1726,7 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m256i t0 = SET1_EPI64(stride);
             __m256i t1 = _mm256_setr_epi64x(0, 1, 2, 3);
@@ -1738,7 +1738,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<4> const & mask, uint64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, uint64_t stride) {
 #if defined(__AVX512DQ__)
             __m256i t0 = SET1_EPI64(stride);
             __m256i t1 = _mm256_setr_epi64x(0, 1, 2, 3);
@@ -1759,13 +1759,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
             __m256i t0 =_mm256_loadu_si256((__m256i *)indices);
             mVec = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
             __m256i t1 = _mm256_i64gather_epi64((__int64 const*)baseAddr, t0, 8);
 #if defined(__AVX512VL__)
@@ -1780,12 +1780,12 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = _mm256_i64gather_epi64((__int64 const*)baseAddr, indices.mVec, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             __m256i t0 = _mm256_i64gather_epi64((__int64 const*)baseAddr, indices.mVec, 8);
 #if defined(__AVX512VL__)
             mVec = _mm256_mask_mov_epi64(mVec, mask.mMask, t0);

--- a/plugins/avx512/uint/UMESimdVecUint64_8.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_8.h
@@ -1503,7 +1503,7 @@ namespace SIMD {
         }
 
         // GATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t * baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -1515,7 +1515,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERU
-        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<8> const & mask, uint64_t* baseAddr, uint64_t stride) {
+        UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<8> const & mask, uint64_t const * baseAddr, uint64_t stride) {
 #if defined (__AVX512DQ__)
             __m512i t0 = _mm512_set1_epi64(stride);
             __m512i t1 = _mm512_setr_epi64(0, 1, 2, 3, 4, 5, 6, 7);
@@ -1528,25 +1528,25 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
             __m512i t0 =_mm512_loadu_si512((__m512i *)indices);
             mVec = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint64_t* baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
             mVec = _mm512_mask_mov_epi64(mVec, mask.mMask, t1);
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = _mm512_i64gather_epi64(indices.mVec, (__int64 const*)baseAddr, 8);
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             __m512i t0 = _mm512_i64gather_epi64(indices.mVec, (__int64 const*)baseAddr, 8);
             mVec = _mm512_mask_mov_epi64(mVec, mask.mMask, t0);
             return *this;

--- a/plugins/avx512/uint/UMESimdVecUint64_8.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_8.h
@@ -1528,13 +1528,13 @@ namespace SIMD {
             return *this;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 =_mm512_loadu_si512((__m512i *)indices);
             mVec = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint64_t const * baseAddr, uint64_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_i64gather_epi64(t0, (__int64 const*)baseAddr, 8);
             mVec = _mm512_mask_mov_epi64(mVec, mask.mMask, t1);

--- a/plugins/openmp/float/UMESimdVecFloatPrototype.h
+++ b/plugins/openmp/float/UMESimdVecFloatPrototype.h
@@ -1930,7 +1930,7 @@ namespace SIMD {
         // MIMIN
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SCALAR_FLOAT_TYPE * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SCALAR_FLOAT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 mVec[i] = baseAddr[indices[i]];
@@ -1938,7 +1938,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_FLOAT_TYPE* baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_FLOAT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 if(mask.mMask[i] == true) mVec[i] = baseAddr[indices[i]];
@@ -1946,7 +1946,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SCALAR_FLOAT_TYPE * baseAddr, SIMDVec_u<SCALAR_UINT_TYPE, VEC_LEN> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SCALAR_FLOAT_TYPE const * baseAddr, SIMDVec_u<SCALAR_UINT_TYPE, VEC_LEN> const & indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 mVec[i] = baseAddr[indices.mVec[i]];
@@ -1954,7 +1954,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_FLOAT_TYPE* baseAddr, SIMDVec_u<SCALAR_UINT_TYPE, VEC_LEN> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_FLOAT_TYPE const * baseAddr, SIMDVec_u<SCALAR_UINT_TYPE, VEC_LEN> const & indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 if(mask.mMask[i] == true) mVec[i] = baseAddr[indices.mVec[i]];

--- a/plugins/openmp/float/UMESimdVecFloatPrototype.h
+++ b/plugins/openmp/float/UMESimdVecFloatPrototype.h
@@ -1930,7 +1930,7 @@ namespace SIMD {
         // MIMIN
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SCALAR_FLOAT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SCALAR_FLOAT_TYPE const * baseAddr, SCALAR_UINT_TYPE const * indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 mVec[i] = baseAddr[indices[i]];
@@ -1938,7 +1938,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_FLOAT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_FLOAT_TYPE const * baseAddr, SCALAR_UINT_TYPE const * indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 if(mask.mMask[i] == true) mVec[i] = baseAddr[indices[i]];

--- a/plugins/openmp/int/UMESimdVecIntPrototype.h
+++ b/plugins/openmp/int/UMESimdVecIntPrototype.h
@@ -2792,7 +2792,7 @@ namespace SIMD {
             return retval;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SCALAR_INT_TYPE * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SCALAR_INT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 mVec[i] = baseAddr[indices[i]];
@@ -2800,7 +2800,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_INT_TYPE* baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_INT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 if(mask.mMask[i] == true) mVec[i] = baseAddr[indices[i]];
@@ -2808,7 +2808,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SCALAR_INT_TYPE * baseAddr, SIMDVec_u<SCALAR_UINT_TYPE, VEC_LEN> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SCALAR_INT_TYPE const * baseAddr, SIMDVec_u<SCALAR_UINT_TYPE, VEC_LEN> const & indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 mVec[i] = baseAddr[indices.mVec[i]];
@@ -2816,7 +2816,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_INT_TYPE* baseAddr, SIMDVec_u<SCALAR_UINT_TYPE, VEC_LEN> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_INT_TYPE const * baseAddr, SIMDVec_u<SCALAR_UINT_TYPE, VEC_LEN> const & indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 if(mask.mMask[i] == true) mVec[i] = baseAddr[indices.mVec[i]];

--- a/plugins/openmp/int/UMESimdVecIntPrototype.h
+++ b/plugins/openmp/int/UMESimdVecIntPrototype.h
@@ -2792,7 +2792,7 @@ namespace SIMD {
             return retval;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SCALAR_INT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SCALAR_INT_TYPE const * baseAddr, SCALAR_UINT_TYPE const * indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 mVec[i] = baseAddr[indices[i]];
@@ -2800,7 +2800,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_INT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_INT_TYPE const * baseAddr, SCALAR_UINT_TYPE const * indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 if(mask.mMask[i] == true) mVec[i] = baseAddr[indices[i]];

--- a/plugins/openmp/uint/UMESimdVecUintPrototype.h
+++ b/plugins/openmp/uint/UMESimdVecUintPrototype.h
@@ -2726,7 +2726,7 @@ namespace SIMD {
             return retval;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SCALAR_UINT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SCALAR_UINT_TYPE const * baseAddr, SCALAR_UINT_TYPE const * indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 mVec[i] = baseAddr[indices[i]];
@@ -2734,7 +2734,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_UINT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_UINT_TYPE const * baseAddr, SCALAR_UINT_TYPE const * indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 if(mask.mMask[i] == true) mVec[i] = baseAddr[indices[i]];

--- a/plugins/openmp/uint/UMESimdVecUintPrototype.h
+++ b/plugins/openmp/uint/UMESimdVecUintPrototype.h
@@ -2726,7 +2726,7 @@ namespace SIMD {
             return retval;
         }
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SCALAR_UINT_TYPE * baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SCALAR_UINT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 mVec[i] = baseAddr[indices[i]];
@@ -2734,7 +2734,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_UINT_TYPE* baseAddr, SCALAR_UINT_TYPE* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_UINT_TYPE const * baseAddr, SCALAR_UINT_TYPE* indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 if(mask.mMask[i] == true) mVec[i] = baseAddr[indices[i]];
@@ -2742,7 +2742,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SCALAR_UINT_TYPE * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SCALAR_UINT_TYPE const * baseAddr, SIMDVec_u const & indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 mVec[i] = baseAddr[indices.mVec[i]];
@@ -2750,7 +2750,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_UINT_TYPE* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<VEC_LEN> const & mask, SCALAR_UINT_TYPE const * baseAddr, SIMDVec_u const & indices) {
             for(int i = 0; i < VEC_LEN; i++)
             {
                 if(mask.mMask[i] == true) mVec[i] = baseAddr[indices.mVec[i]];

--- a/plugins/scalar/float/UMESimdVecFloat32_1.h
+++ b/plugins/scalar/float/UMESimdVecFloat32_1.h
@@ -886,12 +886,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/scalar/float/UMESimdVecFloat32_1.h
+++ b/plugins/scalar/float/UMESimdVecFloat32_1.h
@@ -886,22 +886,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, uint32_t * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<1> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/scalar/float/UMESimdVecFloat32_2.h
+++ b/plugins/scalar/float/UMESimdVecFloat32_2.h
@@ -1062,25 +1062,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, VEC_UINT_TYPE const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/scalar/float/UMESimdVecFloat32_2.h
+++ b/plugins/scalar/float/UMESimdVecFloat32_2.h
@@ -1062,13 +1062,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t * indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/scalar/float/UMESimdVecFloat32_4.h
+++ b/plugins/scalar/float/UMESimdVecFloat32_4.h
@@ -1537,7 +1537,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -1545,7 +1545,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];

--- a/plugins/scalar/float/UMESimdVecFloat32_4.h
+++ b/plugins/scalar/float/UMESimdVecFloat32_4.h
@@ -1537,7 +1537,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -1545,7 +1545,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -1553,7 +1553,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -1561,7 +1561,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<4> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 4> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/scalar/float/UMESimdVecFloat32_8.h
+++ b/plugins/scalar/float/UMESimdVecFloat32_8.h
@@ -2290,7 +2290,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2302,7 +2302,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -2314,7 +2314,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(float * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -2326,7 +2326,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/scalar/float/UMESimdVecFloat32_8.h
+++ b/plugins/scalar/float/UMESimdVecFloat32_8.h
@@ -2290,7 +2290,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(float const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2302,7 +2302,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<8> const & mask, float const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];

--- a/plugins/scalar/int/UMESimdVecInt32_1.h
+++ b/plugins/scalar/int/UMESimdVecInt32_1.h
@@ -1273,12 +1273,12 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/scalar/int/UMESimdVecInt32_1.h
+++ b/plugins/scalar/int/UMESimdVecInt32_1.h
@@ -1273,22 +1273,22 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<1> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<1> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 1> const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/scalar/int/UMESimdVecInt32_2.h
+++ b/plugins/scalar/int/UMESimdVecInt32_2.h
@@ -1487,25 +1487,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/scalar/int/UMESimdVecInt32_2.h
+++ b/plugins/scalar/int/UMESimdVecInt32_2.h
@@ -1487,13 +1487,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/scalar/int/UMESimdVecInt32_4.h
+++ b/plugins/scalar/int/UMESimdVecInt32_4.h
@@ -1869,7 +1869,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -1877,7 +1877,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -1885,7 +1885,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, SIMDVec_i const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_i const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -1893,7 +1893,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t* baseAddr, SIMDVec_i const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, SIMDVec_i const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/scalar/int/UMESimdVecInt32_4.h
+++ b/plugins/scalar/int/UMESimdVecInt32_4.h
@@ -1869,7 +1869,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -1877,7 +1877,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];

--- a/plugins/scalar/int/UMESimdVecInt32_8.h
+++ b/plugins/scalar/int/UMESimdVecInt32_8.h
@@ -2660,7 +2660,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2672,7 +2672,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -2684,7 +2684,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -2696,7 +2696,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 8> const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/scalar/int/UMESimdVecInt32_8.h
+++ b/plugins/scalar/int/UMESimdVecInt32_8.h
@@ -2660,7 +2660,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(int32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2672,7 +2672,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];

--- a/plugins/scalar/uint/UMESimdVecUint32_1.h
+++ b/plugins/scalar/uint/UMESimdVecUint32_1.h
@@ -1169,22 +1169,22 @@ namespace SIMD {
         }
 
         // GATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec = baseAddr[indices.mVec];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u gather(SIMDVecMask<1> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask == true) mVec = baseAddr[indices.mVec];
             return *this;
         }

--- a/plugins/scalar/uint/UMESimdVecUint32_1.h
+++ b/plugins/scalar/uint/UMESimdVecUint32_1.h
@@ -1169,12 +1169,12 @@ namespace SIMD {
         }
 
         // GATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec = baseAddr[indices[0]];
             return *this;
         }
         // MGATHER
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<1> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask == true) mVec = baseAddr[indices[0]];
             return *this;
         }

--- a/plugins/scalar/uint/UMESimdVecUint32_2.h
+++ b/plugins/scalar/uint/UMESimdVecUint32_2.h
@@ -1386,13 +1386,13 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;

--- a/plugins/scalar/uint/UMESimdVecUint32_2.h
+++ b/plugins/scalar/uint/UMESimdVecUint32_2.h
@@ -1386,25 +1386,25 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;

--- a/plugins/scalar/uint/UMESimdVecUint32_4.h
+++ b/plugins/scalar/uint/UMESimdVecUint32_4.h
@@ -1800,7 +1800,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -1808,7 +1808,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];

--- a/plugins/scalar/uint/UMESimdVecUint32_4.h
+++ b/plugins/scalar/uint/UMESimdVecUint32_4.h
@@ -1800,7 +1800,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -1808,7 +1808,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -1816,7 +1816,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -1824,7 +1824,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/scalar/uint/UMESimdVecUint32_8.h
+++ b/plugins/scalar/uint/UMESimdVecUint32_8.h
@@ -2654,7 +2654,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2666,7 +2666,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t* baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];
@@ -2678,7 +2678,7 @@ namespace SIMD {
             return *this;
         }
         // GATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t * baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, SIMDVec_u const & indices) {
             mVec[0] = baseAddr[indices.mVec[0]];
             mVec[1] = baseAddr[indices.mVec[1]];
             mVec[2] = baseAddr[indices.mVec[2]];
@@ -2690,7 +2690,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERV
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices.mVec[2]];

--- a/plugins/scalar/uint/UMESimdVecUint32_8.h
+++ b/plugins/scalar/uint/UMESimdVecUint32_8.h
@@ -2654,7 +2654,7 @@ namespace SIMD {
         }
 
         // GATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(uint32_t const * baseAddr, uint32_t const * indices) {
             mVec[0] = baseAddr[indices[0]];
             mVec[1] = baseAddr[indices[1]];
             mVec[2] = baseAddr[indices[2]];
@@ -2666,7 +2666,7 @@ namespace SIMD {
             return *this;
         }
         // MGATHERS
-        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t* indices) {
+        UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
             if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
             if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
             if (mask.mMask[2] == true) mVec[2] = baseAddr[indices[2]];


### PR DESCRIPTION
This fixes #2.

The changes were made with

```
find . -path ./.git -prune -o -type f -name "*" -print0 | xargs -0 perl -p -i -e 's/(.+?(?:inline|INLINE).+?gather.+?\w)(\s*[*]\s*)/\1 const * /'
find . -path ./.git -prune -o -type f -name "*" -print0 | xargs -0 perl -p -i -e 's/(.+?(?:inline|INLINE).+?gather.+?const [*].+?\w)(\s*[*]\s*)/\1 const * /'
```

An example:

```c++
inline SIMDVec_f & gather(double * baseAddr, uint64_t * indices) {
    mVec[0] = baseAddr[indices[0]];
    mVec[1] = baseAddr[indices[1]];
    return *this;
}
```

transformed into

```c++
inline SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
    mVec[0] = baseAddr[indices[0]];
    mVec[1] = baseAddr[indices[1]];
    return *this;
}
```