### PR TITLE
Fix some swizzle errors

### DIFF
--- a/plugins/avx512/swizzle/UMESimdSwizzle16.h
+++ b/plugins/avx512/swizzle/UMESimdSwizzle16.h
@@ -85,7 +85,7 @@ namespace SIMD {
         // A non-modifying element-wise access operator
         UME_FORCE_INLINE uint32_t extract(uint32_t index) const
         {
-            alignas(16) uint32_t raw[4];
+            alignas(16) uint32_t raw[16];
             _mm512_store_si512((__m512i*) raw, mVec);
             return raw[index];
         }
@@ -94,7 +94,7 @@ namespace SIMD {
 
         // Element-wise modification operator
         UME_FORCE_INLINE SIMDSwizzle & insert(uint32_t index, uint32_t value) {
-            alignas(16) uint32_t raw[4];
+            alignas(16) uint32_t raw[16];
             _mm512_store_si512((__m512i*)raw, mVec);
             raw[index] = value;
             mVec = _mm512_load_si512((__m512i*)raw);

--- a/plugins/avx512/swizzle/UMESimdSwizzle8.h
+++ b/plugins/avx512/swizzle/UMESimdSwizzle8.h
@@ -81,7 +81,7 @@ namespace SIMD {
         // A non-modifying element-wise access operator
         UME_FORCE_INLINE uint32_t extract(uint32_t index) const
         {
-            alignas(16) uint32_t raw[4];
+            alignas(16) uint32_t raw[8];
             _mm256_store_si256((__m256i*) raw, mVec);
             return raw[index];
         }
@@ -90,7 +90,7 @@ namespace SIMD {
 
         // Element-wise modification operator
         UME_FORCE_INLINE SIMDSwizzle & insert(uint32_t index, uint32_t value) {
-            alignas(16) uint32_t raw[4];
+            alignas(16) uint32_t raw[8];
             _mm256_store_si256((__m256i*)raw, mVec);
             raw[index] = value;
             mVec = _mm256_load_si256((__m256i*)raw);

--- a/plugins/avx512/uint/UMESimdVecUint64_16.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_16.h
@@ -289,7 +289,7 @@ namespace SIMD {
             }
             
             mVec[0] = _mm512_load_epi64(&result[0]);
-            mVec[1] = _mm512_load_epi64(&result[1]);
+            mVec[1] = _mm512_load_epi64(&result[8]);
             return *this;
         }
         // ADDV


### PR DESCRIPTION
### plugins/avx512/uint/UMESimdVecUint64_16.h:
I already commented this in https://github.com/edanor/umesimd/issues/53#issuecomment-274279689 that you use the wrong address for the load

### other files:
The buffer sizes for 8 or 16 elements in the swizzle operations are fixed at 4, which is to small.
gcc-6 caught this error.