### PR TITLE
Install in umesimd rather than ume/simd.  Avoid duplication subdirectory names.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,10 @@ file(GLOB top_files
         README.md
         LICENSE)
 
-install(DIRECTORY doc DESTINATION include/ume/simd/doc)
-install(DIRECTORY examples DESTINATION include/ume/simd/examples)
-install(DIRECTORY plugins DESTINATION include/ume/simd/plugins)
-install(DIRECTORY utilities DESTINATION include/ume/simd/utilities)
-install(FILES ${top_files} DESTINATION include/ume/simd)
+install(DIRECTORY doc DESTINATION include/umesimd)
+install(DIRECTORY examples DESTINATION include/umesimd)
+install(DIRECTORY plugins DESTINATION include/umesimd)
+install(DIRECTORY utilities DESTINATION include/umesimd)
+install(FILES ${top_files} DESTINATION include/umesimd)
 
 include(CPack)


### PR DESCRIPTION


So for example instead of:
   include/ume/simd/plugins/plugins/UMESimdPluginAVX2.h
we now have
   include/umesimd/plugins/UMESimdPluginAVX2.h