### PR TITLE
quick fix for build problem with gcc7 on knl (avx512)

### DIFF
--- a/plugins/UMESimdPluginAVX512.h
+++ b/plugins/UMESimdPluginAVX512.h
@@ -50,7 +50,7 @@
 
 
 // WA: missing intrinsics in GCC
-#if __GNUC__ < 6 || (__GNUC__ == 6 && (__GNUC_MINOR < 2))
+#if __GNUC__ < 6 || (__GNUC__ == 6 && (__GNUC_MINOR < 2)) || __GNUC__ >= 7
 #define WA_GCC_INTR_SUPPORT_6_2
 #endif
 


### PR DESCRIPTION
hi,
short fix for someone who tried running umesimd on knl. is the problem that it wants long long int* instead of the int64_t