### PR TITLE
Merge avx512 gcc7 scrutinyfix

### DIFF
--- a/plugins/UMESimdPluginAVX512.h
+++ b/plugins/UMESimdPluginAVX512.h
@@ -54,7 +54,7 @@
 #define WA_GCC_INTR_SUPPORT_6_2
 #endif
 
-#if __GNUC__ >= 7
+#if __GNUC__ >= 7 && ! defined(__INTEL_COMPILER)
 #define WA_GCC_INTR_SUPPORT_7
 #endif
 

--- a/plugins/UMESimdPluginAVX512.h
+++ b/plugins/UMESimdPluginAVX512.h
@@ -50,8 +50,12 @@
 
 
 // WA: missing intrinsics in GCC
-#if __GNUC__ < 6 || (__GNUC__ == 6 && (__GNUC_MINOR < 2)) || __GNUC__ >= 7
+#if __GNUC__ < 6 || (__GNUC__ == 6 && (__GNUC_MINOR < 2))
 #define WA_GCC_INTR_SUPPORT_6_2
+#endif
+
+#if __GNUC__ >= 7
+#define WA_GCC_INTR_SUPPORT_7
 #endif
 
 namespace UME

--- a/plugins/UMESimdPluginAVX512.h
+++ b/plugins/UMESimdPluginAVX512.h
@@ -50,7 +50,7 @@
 
 
 // WA: missing intrinsics in GCC
-#if __GNUC__ < 6 || (__GNUC__ == 6 && (__GNUC_MINOR < 2))
+#if __GNUC__ < 6 || (__GNUC__ == 6 && (__GNUC_MINOR < 2)) || __GNUC__ >= 7
 #define WA_GCC_INTR_SUPPORT_6_2
 #endif
 

--- a/plugins/avx2/float/UMESimdVecFloat32_16.h
+++ b/plugins/avx2/float/UMESimdVecFloat32_16.h
@@ -936,7 +936,7 @@ namespace SIMD {
             _mm256_store_si256((__m256i*)raw, m1);
             __m256 m2 = _mm256_cmp_ps(mVec[1], t0, _CMP_EQ_OS);
             __m256i m3 = _mm256_castps_si256(m2);
-            _mm256_store_si256((__m256i*)raw, m3);
+            _mm256_store_si256((__m256i*)(raw + 8), m3);
             return (raw[0] != 0) && (raw[1] != 0) && (raw[2] != 0) && (raw[3] !=0) &&
                    (raw[4] != 0) && (raw[5] != 0) && (raw[6] != 0) && (raw[7] !=0) &&
                    (raw[8] != 0) && (raw[9] != 0) && (raw[10] != 0) && (raw[11] != 0) &&

--- a/plugins/avx512/float/UMESimdVecFloat32_16.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_16.h
@@ -1727,7 +1727,7 @@ namespace SIMD {
         // MCTAN
         // PACK
         UME_FORCE_INLINE SIMDVec_f & pack(SIMDVec_f<float, 8> const & a, SIMDVec_f<float, 8> const & b) {
-#if defined(__AVX512VL__)
+#if defined(__AVX512DQ__)
             mVec = _mm512_insertf32x8(mVec, a.mVec, 0);
             mVec = _mm512_insertf32x8(mVec, b.mVec, 1);
 #else
@@ -1740,7 +1740,7 @@ namespace SIMD {
         }
         // PACKLO
         UME_FORCE_INLINE SIMDVec_f & packlo(SIMDVec_f<float, 8> const & a) {
-#if defined(__AVX512VL__)
+#if defined(__AVX512DQ__)
             mVec = _mm512_insertf32x8(mVec, a.mVec, 0);
 #else
             alignas(64) float raw[16];

--- a/plugins/avx512/float/UMESimdVecFloat32_32.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_32.h
@@ -1554,7 +1554,7 @@ namespace SIMD {
             float t12 = t7 < t8 ? t7 : t8;
 
             float t13 = t9 < t10 ? t9 : t10;
-            float t14 = t10 < t12 ? t11 : t12;
+            float t14 = t11 < t12 ? t11 : t12;
 
             return t13 < t14 ? t13 : t14;
 #else

--- a/plugins/avx512/float/UMESimdVecFloat32_32.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_32.h
@@ -1203,7 +1203,7 @@ namespace SIMD {
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             __mmask16 m1 = (mask.mMask & 0xFFFF0000) >> 16;
             float t0 = _mm512_mask_reduce_mul_ps(m0, mVec[0]);
-            t0 *= _mm512_mask_reduce_mul_ps(m0, mVec[1]);
+            t0 *= _mm512_mask_reduce_mul_ps(m1, mVec[1]);
             return t0;
 #endif
         }

--- a/plugins/avx512/float/UMESimdVecFloat32_4.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_4.h
@@ -1551,8 +1551,10 @@ namespace SIMD {
             float t1 = (raw[2] < raw[3]) ? raw[2] : raw[3];
             return t0 < t1 ? t0 : t1;
 #else
+	    __m512 max = _mm512_set1_ps(std::numeric_limits<float>::max()); 
             __m512 t0 = _mm512_castps128_ps512(mVec);
-            float retval = _mm512_reduce_min_ps(t0);
+	    __m512 t1 = _mm512_mask_blend_ps(0xF, max, t0);
+            float retval = _mm512_reduce_min_ps(t1);
             return retval;
 #endif
         }

--- a/plugins/avx512/float/UMESimdVecFloat32_8.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_8.h
@@ -1182,7 +1182,7 @@ namespace SIMD {
             return t0 + t1 + t2 + t3 + t4 + t5 + t6 + t7;
 #else
             __m512 t0 = _mm512_castps256_ps512(mVec);
-            __mmask16 t1 = (__mmask16)mask.mMask & 0xFF;
+            __mmask16 t1 = ((__mmask16)mask.mMask) & 0xFFFF;
             float retval = _mm512_mask_reduce_add_ps(t1, t0);
             return retval;
 #endif
@@ -1204,18 +1204,18 @@ namespace SIMD {
 #if defined(WA_GCC_INTR_SUPPORT_6_2)
             alignas(32) float raw[8];
             _mm256_store_ps(raw, mVec);
-            uint32_t t0 = ((mask.mMask & 0x01) != 0) ? raw[0] : 0.0f;
-            uint32_t t1 = ((mask.mMask & 0x02) != 0) ? raw[1] : 0.0f;
-            uint32_t t2 = ((mask.mMask & 0x04) != 0) ? raw[2] : 0.0f;
-            uint32_t t3 = ((mask.mMask & 0x08) != 0) ? raw[3] : 0.0f;
-            uint32_t t4 = ((mask.mMask & 0x10) != 0) ? raw[4] : 0.0f;
-            uint32_t t5 = ((mask.mMask & 0x20) != 0) ? raw[5] : 0.0f;
-            uint32_t t6 = ((mask.mMask & 0x40) != 0) ? raw[6] : 0.0f;
-            uint32_t t7 = ((mask.mMask & 0x80) != 0) ? raw[7] : 0.0f;
+            float t0 = ((mask.mMask & 0x01) != 0) ? raw[0] : 0.0f;
+            float t1 = ((mask.mMask & 0x02) != 0) ? raw[1] : 0.0f;
+            float t2 = ((mask.mMask & 0x04) != 0) ? raw[2] : 0.0f;
+            float t3 = ((mask.mMask & 0x08) != 0) ? raw[3] : 0.0f;
+            float t4 = ((mask.mMask & 0x10) != 0) ? raw[4] : 0.0f;
+            float t5 = ((mask.mMask & 0x20) != 0) ? raw[5] : 0.0f;
+            float t6 = ((mask.mMask & 0x40) != 0) ? raw[6] : 0.0f;
+            float t7 = ((mask.mMask & 0x80) != 0) ? raw[7] : 0.0f;
             return b + t0 + t1 + t2 + t3 + t4 + t5 + t6 + t7;
 #else
             __m512 t0 = _mm512_castps256_ps512(mVec);
-            __mmask16 t1 = (__mmask16)mask.mMask & 0xFF;
+            __mmask16 t1 = ((__mmask16)mask.mMask) & 0xFFFF;
             float retval = _mm512_mask_reduce_add_ps(t1, t0);
             return retval + b;
 #endif

--- a/plugins/avx512/float/UMESimdVecFloat32_8.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_8.h
@@ -2316,7 +2316,11 @@ namespace SIMD {
             mVec = _mm256_load_ps(raw);
             return *this;
  #else
+ #if defined (WA_GCC_INTR_SUPPORT_7)
+	   mVec = _mm256_permute2f128_ps(_mm256_castps128_ps256(a.mVec), _mm256_castps128_ps256(b.mVec), 0x20); 
+ #else 
             mVec = _mm256_set_m128(b.mVec, a.mVec);
+ #endif
             return *this;
  #endif
         }

--- a/plugins/avx512/float/UMESimdVecFloat32_8.h
+++ b/plugins/avx512/float/UMESimdVecFloat32_8.h
@@ -2309,6 +2309,7 @@ namespace SIMD {
         // MCTAN
         // PACK
         UME_FORCE_INLINE SIMDVec_f & pack(SIMDVec_f<float, 4> const & a, SIMDVec_f<float, 4> const & b) {
+/*
  #if defined (WA_GCC_INTR_SUPPORT_7_1)
             alignas(32) float raw[8];
             _mm_store_ps(raw, a.mVec);
@@ -2316,13 +2317,14 @@ namespace SIMD {
             mVec = _mm256_load_ps(raw);
             return *this;
  #else
- #if defined (WA_GCC_INTR_SUPPORT_7_1)
+*/
+// #if defined (WA_GCC_INTR_SUPPORT_7_1)
 	   mVec = _mm256_permute2f128_ps(_mm256_castps128_ps256(a.mVec), _mm256_castps128_ps256(b.mVec), 0x20); 
- #else 
-            mVec = _mm256_set_m128(b.mVec, a.mVec);
- #endif
+// #else
+//            mVec = _mm256_set_m128(b.mVec, a.mVec);
+// #endif
             return *this;
- #endif
+// #endif
         }
         // PACKLO
         UME_FORCE_INLINE SIMDVec_f & packlo(SIMDVec_f<float, 4> const & a) {

--- a/plugins/avx512/float/UMESimdVecFloat64_16.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_16.h
@@ -1501,8 +1501,13 @@ namespace SIMD {
             __m512d t6 = _mm512_castsi512_pd(t4);
             return SIMDVec_f(t5, t6);
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512d t0 = _mm512_abs_pd(_mm512_castpd_ps(mVec[0]));
+            __m512d t1 = _mm512_abs_pd(_mm512_castpd_ps(mVec[1]));
+#else
             __m512d t0 = _mm512_abs_pd(mVec[0]);
             __m512d t1 = _mm512_abs_pd(mVec[1]);
+#endif
             return SIMDVec_f(t0, t1);
 #endif
         }
@@ -1520,8 +1525,13 @@ namespace SIMD {
             __m512d t8 = _mm512_mask_mov_pd(mVec[1], ((mask.mMask & 0xFF00) >> 8), t6);
             return SIMDVec_f(t7, t8);
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512d t0 = _mm512_mask_abs_pd(mVec[0], mask.mMask & 0xFF, _mm512_castpd_ps(mVec[0]));
+            __m512d t1 = _mm512_mask_abs_pd(mVec[1], ((mask.mMask & 0xFF00) >> 8), _mm512_castpd_ps(mVec[1]));
+#else
             __m512d t0 = _mm512_mask_abs_pd(mVec[0], mask.mMask & 0xFF, mVec[0]);
             __m512d t1 = _mm512_mask_abs_pd(mVec[1], ((mask.mMask & 0xFF00) >> 8), mVec[1]);
+#endif
             return SIMDVec_f(t0, t1);
 #endif
         }
@@ -1537,8 +1547,14 @@ namespace SIMD {
             mVec[1] = _mm512_castsi512_pd(t4);
             return *this;
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            mVec[0] = _mm512_abs_pd(_mm512_castpd_ps(mVec[0]));
+            mVec[1] = _mm512_abs_pd(_mm512_castpd_ps(mVec[1]));
+#else
             mVec[0] = _mm512_abs_pd(mVec[0]);
             mVec[1] = _mm512_abs_pd(mVec[1]);
+#endif
+
             return *this;
 #endif
         }
@@ -1556,8 +1572,13 @@ namespace SIMD {
             mVec[1] = _mm512_mask_mov_pd(mVec[1], ((mask.mMask & 0xFF00) >> 8), t6);
             return *this;
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            mVec[0] = _mm512_mask_abs_pd(mVec[0], mask.mMask & 0xFF, _mm512_castpd_ps(mVec[0]));
+            mVec[1] = _mm512_mask_abs_pd(mVec[1], ((mask.mMask & 0xFF00) >> 8), _mm512_castpd_ps(mVec[1]));
+#else
             mVec[0] = _mm512_mask_abs_pd(mVec[0], mask.mMask & 0xFF, mVec[0]);
             mVec[1] = _mm512_mask_abs_pd(mVec[1], ((mask.mMask & 0xFF00) >> 8), mVec[1]);
+#endif
             return *this;
 #endif
         }

--- a/plugins/avx512/float/UMESimdVecFloat64_16.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_16.h
@@ -1491,7 +1491,7 @@ namespace SIMD {
         }
         // ABS
         UME_FORCE_INLINE SIMDVec_f abs() const {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512i t0 = _mm512_castpd_si512(mVec[0]);
             __m512i t1 = _mm512_castpd_si512(mVec[1]);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
@@ -1513,7 +1513,7 @@ namespace SIMD {
         }
         // MABS
         UME_FORCE_INLINE SIMDVec_f abs(SIMDVecMask<16> const & mask) const {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512i t0 = _mm512_castpd_si512(mVec[0]);
             __m512i t1 = _mm512_castpd_si512(mVec[1]);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
@@ -1537,7 +1537,7 @@ namespace SIMD {
         }
         // ABSA
         UME_FORCE_INLINE SIMDVec_f & absa() {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512i t0 = _mm512_castpd_si512(mVec[0]);
             __m512i t1 = _mm512_castpd_si512(mVec[1]);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
@@ -1560,7 +1560,7 @@ namespace SIMD {
         }
         // MABSA
         UME_FORCE_INLINE SIMDVec_f & absa(SIMDVecMask<16> const & mask) {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512i t0 = _mm512_castpd_si512(mVec[0]);
             __m512i t1 = _mm512_castpd_si512(mVec[1]);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);

--- a/plugins/avx512/float/UMESimdVecFloat64_2.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_2.h
@@ -1673,7 +1673,11 @@ namespace SIMD {
             __m128d t5 = _mm512_castpd512_pd128(t4);
             return SIMDVec_f(t5);
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512 t0 = _mm512_castpd_ps(_mm512_castpd128_pd512(mVec)); //wrong implementation in gcc7 
+#else
             __m512d t0 = _mm512_castpd128_pd512(mVec);
+#endif
             __m512d t1 = _mm512_abs_pd(t0);
             __m128d t2 = _mm512_castpd512_pd128(t1);
             return SIMDVec_f(t2);
@@ -1691,8 +1695,14 @@ namespace SIMD {
             __m128d t6 = _mm512_castpd512_pd128(t5);
             return SIMDVec_f(t6);
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512 t0 = _mm512_castpd_ps(_mm512_castpd128_pd512(mVec)); //wrong implementation in gcc7 
+            __m512d t2 = _mm512_mask_abs_pd(_mm512_castps_pd(t0), mask.mMask, t0);
+#else
             __m512d t0 = _mm512_castpd128_pd512(mVec);
             __m512d t2 = _mm512_mask_abs_pd(t0, mask.mMask, t0);
+#endif
+
             __m128d t3 = _mm512_castpd512_pd128(t2);
             return SIMDVec_f(t3);
 #endif
@@ -1708,7 +1718,11 @@ namespace SIMD {
             mVec = _mm512_castpd512_pd128(t4);
             return *this;
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512 t0 = _mm512_castpd_ps(_mm512_castpd128_pd512(mVec)); //wrong implementation in gcc7 
+#else
             __m512d t0 = _mm512_castpd128_pd512(mVec);
+#endif
             __m512d t1 = _mm512_abs_pd(t0);
             mVec = _mm512_castpd512_pd128(t1);
             return *this;
@@ -1726,8 +1740,13 @@ namespace SIMD {
             mVec = _mm512_castpd512_pd128(t5);
             return *this;
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512 t0 = _mm512_castpd_ps(_mm512_castpd128_pd512(mVec)); //wrong implementation in gcc7 
+            __m512d t2 = _mm512_mask_abs_pd(_mm512_castps_pd(t0), mask.mMask, t0);
+#else
             __m512d t0 = _mm512_castpd128_pd512(mVec);
             __m512d t2 = _mm512_mask_abs_pd(t0, mask.mMask, t0);
+#endif
             mVec = _mm512_castpd512_pd128(t2);
             return *this;
 #endif

--- a/plugins/avx512/float/UMESimdVecFloat64_2.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_2.h
@@ -1664,7 +1664,7 @@ namespace SIMD {
         }
         // ABS
         UME_FORCE_INLINE SIMDVec_f abs() const {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512d t0 = _mm512_castpd128_pd512(mVec);
             __m512i t1 = _mm512_castpd_si512(t0);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
@@ -1685,7 +1685,7 @@ namespace SIMD {
         }
         // MABS
         UME_FORCE_INLINE SIMDVec_f abs(SIMDVecMask<2> const & mask) const {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512d t0 = _mm512_castpd128_pd512(mVec);
             __m512i t1 = _mm512_castpd_si512(t0);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
@@ -1709,7 +1709,7 @@ namespace SIMD {
         }
         // ABSA
         UME_FORCE_INLINE SIMDVec_f & absa() {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512d t0 = _mm512_castpd128_pd512(mVec);
             __m512i t1 = _mm512_castpd_si512(t0);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
@@ -1730,7 +1730,7 @@ namespace SIMD {
         }
         // MABSA
         UME_FORCE_INLINE SIMDVec_f & absa(SIMDVecMask<2> const & mask) {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512d t0 = _mm512_castpd128_pd512(mVec);
             __m512i t1 = _mm512_castpd_si512(t0);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);

--- a/plugins/avx512/float/UMESimdVecFloat64_4.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_4.h
@@ -1701,7 +1701,7 @@ namespace SIMD {
         }
         // ABS
         UME_FORCE_INLINE SIMDVec_f abs() const {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512d t0 = _mm512_castpd256_pd512(mVec);
             __m512i t1 = _mm512_castpd_si512(t0);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
@@ -1722,7 +1722,7 @@ namespace SIMD {
         }
         // MABS
         UME_FORCE_INLINE SIMDVec_f abs(SIMDVecMask<4> const & mask) const {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512d t0 = _mm512_castpd256_pd512(mVec);
             __m512i t1 = _mm512_castpd_si512(t0);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
@@ -1745,7 +1745,7 @@ namespace SIMD {
         }
         // ABSA
         UME_FORCE_INLINE SIMDVec_f & absa() {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512d t0 = _mm512_castpd256_pd512(mVec);
             __m512i t1 = _mm512_castpd_si512(t0);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
@@ -1766,7 +1766,7 @@ namespace SIMD {
         }
         // MABSA
         UME_FORCE_INLINE SIMDVec_f & absa(SIMDVecMask<4> const & mask) {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512d t0 = _mm512_castpd256_pd512(mVec);
             __m512i t1 = _mm512_castpd_si512(t0);
             __m512i t2 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);

--- a/plugins/avx512/float/UMESimdVecFloat64_4.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_4.h
@@ -1710,7 +1710,11 @@ namespace SIMD {
             __m256d t5 = _mm512_castpd512_pd256(t4);
             return SIMDVec_f(t5);
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512 t0 = _mm512_castpd_ps(_mm512_castpd256_pd512(mVec));
+#else
             __m512d t0 = _mm512_castpd256_pd512(mVec);
+#endif
             __m512d t1 = _mm512_abs_pd(t0);
             __m256d t2 = _mm512_castpd512_pd256(t1);
             return SIMDVec_f(t2);
@@ -1728,8 +1732,13 @@ namespace SIMD {
             __m256d t6 = _mm512_castpd512_pd256(t5);
             return SIMDVec_f(t6);
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512d t0 = _mm512_castpd256_pd512(mVec);
+            __m512d t2 = _mm512_mask_abs_pd(t0, mask.mMask, _mm512_castpd_ps(t0));
+#else
             __m512d t0 = _mm512_castpd256_pd512(mVec);
             __m512d t2 = _mm512_mask_abs_pd(t0, mask.mMask, t0);
+#endif
             __m256d t3 = _mm512_castpd512_pd256(t2);
             return SIMDVec_f(t3);
 #endif
@@ -1745,7 +1754,11 @@ namespace SIMD {
             mVec = _mm512_castpd512_pd256(t4);
             return *this;
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512 t0 = _mm512_castpd_ps(_mm512_castpd256_pd512(mVec));
+#else
             __m512d t0 = _mm512_castpd256_pd512(mVec);
+#endif
             __m512d t1 = _mm512_abs_pd(t0);
             mVec = _mm512_castpd512_pd256(t1);
             return *this;
@@ -1763,8 +1776,13 @@ namespace SIMD {
             mVec = _mm512_castpd512_pd256(t5);
             return *this;
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512d t0 = _mm512_castpd256_pd512(mVec);
+            __m512d t2 = _mm512_mask_abs_pd(t0, mask.mMask, _mm512_castpd_ps(t0));
+#else
             __m512d t0 = _mm512_castpd256_pd512(mVec);
             __m512d t2 = _mm512_mask_abs_pd(t0, mask.mMask, t0);
+#endif
             mVec = _mm512_castpd512_pd256(t2);
             return *this;
 #endif

--- a/plugins/avx512/float/UMESimdVecFloat64_4.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_4.h
@@ -1497,7 +1497,7 @@ namespace SIMD {
 #if defined (WA_GCC_INTR_SUPPORT_6_2)
             alignas(32) double raw[4];
             _mm256_store_pd(raw, mVec);
-            double t0 = (mask.mMask & 0x1) ? raw[0] : std::numeric_limits<double>::lowest();
+            double t0 = (mask.mMask & 0x1) ? raw[0] : std::numeric_limits<double>::max();
             double t1 = ((mask.mMask & 0x2) && raw[1] < t0) ? raw[1] : t0;
             double t2 = ((mask.mMask & 0x4) && raw[2] < t1) ? raw[2] : t1;
             double t3 = ((mask.mMask & 0x8) && raw[3] < t2) ? raw[3] : t2;

--- a/plugins/avx512/float/UMESimdVecFloat64_8.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_8.h
@@ -1245,7 +1245,7 @@ namespace SIMD {
         }
         // ABS
         UME_FORCE_INLINE SIMDVec_f abs() const {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512i t0 = _mm512_castpd_si512(mVec);
             __m512i t1 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
             __m512i t2 = _mm512_and_epi64(t0, t1);
@@ -1262,7 +1262,7 @@ namespace SIMD {
         }
         // MABS
         UME_FORCE_INLINE SIMDVec_f abs(SIMDVecMask<8> const & mask) const {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512i t0 = _mm512_castpd_si512(mVec);
             __m512i t1 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
             __m512i t2 = _mm512_and_epi64(t0, t1);
@@ -1280,7 +1280,7 @@ namespace SIMD {
         }
         // ABSA
         UME_FORCE_INLINE SIMDVec_f & absa() {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512i t0 = _mm512_castpd_si512(mVec);
             __m512i t1 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
             __m512i t2 = _mm512_and_epi64(t0, t1);
@@ -1297,7 +1297,7 @@ namespace SIMD {
         }
         // MABSA
         UME_FORCE_INLINE SIMDVec_f & absa(SIMDVecMask<8> const & mask) {
-#if defined (WA_GCC_INTR_SUPPORT_7_1)
+#if defined (WA_GCC_INTR_SUPPORT_6_4)
             __m512i t0 = _mm512_castpd_si512(mVec);
             __m512i t1 = _mm512_set1_epi64(0x7FFFFFFFFFFFFFFF);
             __m512i t2 = _mm512_and_epi64(t0, t1);

--- a/plugins/avx512/float/UMESimdVecFloat64_8.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_8.h
@@ -1102,7 +1102,7 @@ namespace SIMD {
 #if defined (WA_GCC_INTR_SUPPORT_6_2)
             alignas(64) double raw[8];
             _mm512_store_pd(raw, mVec);
-            double t0 = ((mask.mMask & 0x01) != 0) ? raw[0] : std::numeric_limits<double>::lowest();
+            double t0 = ((mask.mMask & 0x01) != 0) ? raw[0] : std::numeric_limits<double>::max();
             double t1 = (((mask.mMask & 0x02) != 0) && raw[1] < t0) ? raw[1] : t0;
             double t2 = (((mask.mMask & 0x04) != 0) && raw[2] < t1) ? raw[2] : t1;
             double t3 = (((mask.mMask & 0x08) != 0) && raw[3] < t2) ? raw[3] : t2;

--- a/plugins/avx512/float/UMESimdVecFloat64_8.h
+++ b/plugins/avx512/float/UMESimdVecFloat64_8.h
@@ -1252,7 +1252,11 @@ namespace SIMD {
             __m512d t3 = _mm512_castsi512_pd(t2);
             return SIMDVec_f(t3);
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512d t0 = _mm512_abs_pd(_mm512_castpd_ps(mVec));
+#else
             __m512d t0 = _mm512_abs_pd(mVec);
+#endif
             return SIMDVec_f(t0);
 #endif
         }
@@ -1266,7 +1270,11 @@ namespace SIMD {
             __m512d t4 = _mm512_mask_mov_pd(mVec, mask.mMask, t3);
             return SIMDVec_f(t4);
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            __m512d t0 = _mm512_mask_abs_pd(mVec, mask.mMask, _mm512_castpd_ps(mVec));
+#else
             __m512d t0 = _mm512_mask_abs_pd(mVec, mask.mMask, mVec);
+#endif
             return SIMDVec_f(t0);
 #endif
         }
@@ -1279,7 +1287,11 @@ namespace SIMD {
             mVec = _mm512_castsi512_pd(t2);
             return *this;
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            mVec = _mm512_abs_pd(_mm512_castpd_ps(mVec));
+#else
             mVec = _mm512_abs_pd(mVec);
+#endif
             return *this;
 #endif
         }
@@ -1293,7 +1305,11 @@ namespace SIMD {
             mVec = _mm512_mask_mov_pd(mVec, mask.mMask, t3);
             return *this;
 #else
+#if defined (WA_GCC_INTR_SUPPORT_7)
+            mVec = _mm512_mask_abs_pd(mVec, mask.mMask, _mm512_castpd_ps(mVec));
+#else
             mVec = _mm512_mask_abs_pd(mVec, mask.mMask, mVec);
+#endif
             return *this;
 #endif
         }

--- a/plugins/avx512/int/UMESimdVecInt32_16.h
+++ b/plugins/avx512/int/UMESimdVecInt32_16.h
@@ -698,7 +698,7 @@ namespace SIMD {
             alignas(64) int32_t raw[16];
             _mm512_store_si512((__m512i*)raw, mVec);
             return b + raw[0] + raw[1] + raw[2]  + raw[3]  + raw[4]  + raw[5]  + raw[6]  + raw[7] +
-                   raw[9] + raw[9] + raw[10] + raw[11] + raw[12] + raw[13] + raw[14] + raw[15];
+                   raw[8] + raw[9] + raw[10] + raw[11] + raw[12] + raw[13] + raw[14] + raw[15];
 #else
             int32_t retval = _mm512_reduce_add_epi32(mVec);
             return retval + b;
@@ -738,7 +738,7 @@ namespace SIMD {
             alignas(64) int32_t raw[16];
             _mm512_store_si512((__m512i*)raw, mVec);
             return raw[0] * raw[1] * raw[2]  * raw[3]  * raw[4]  * raw[5]  * raw[6]  * raw[7] *
-                   raw[9] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
+                   raw[8] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
 #else
             int32_t retval = _mm512_reduce_mul_epi32(mVec);
             return retval;
@@ -778,7 +778,7 @@ namespace SIMD {
             alignas(64) int32_t raw[16];
             _mm512_store_si512((__m512i*)raw, mVec);
             return b * raw[0] * raw[1] * raw[2]  * raw[3]  * raw[4]  * raw[5]  * raw[6]  * raw[7] *
-                   raw[9] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
+                   raw[8] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
 #else
             int32_t retval = b;
             retval *= _mm512_reduce_mul_epi32(mVec);

--- a/plugins/avx512/int/UMESimdVecInt32_32.h
+++ b/plugins/avx512/int/UMESimdVecInt32_32.h
@@ -1026,8 +1026,8 @@ namespace SIMD {
 #else
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             __mmask16 m1 = (mask.mMask & 0xFFFF0000) >> 16;
-            int32_t t0 = _mm512_mask_reduce_add_epi32(m0, mVec[0]);
-            int32_t t1 = _mm512_mask_reduce_add_epi32(m1, mVec[1]);
+            int32_t t0 = _mm512_mask_reduce_mul_epi32(m0, mVec[0]);
+            int32_t t1 = _mm512_mask_reduce_mul_epi32(m1, mVec[1]);
             return t0 * t1;
 #endif
         }
@@ -1088,8 +1088,8 @@ namespace SIMD {
 #else
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             __mmask16 m1 = (mask.mMask & 0xFFFF0000) >> 16;
-            int32_t t0 = _mm512_mask_reduce_add_epi32(m0, mVec[0]);
-            int32_t t1 = _mm512_mask_reduce_add_epi32(m1, mVec[1]);
+            int32_t t0 = _mm512_mask_reduce_mul_epi32(m0, mVec[0]);
+            int32_t t1 = _mm512_mask_reduce_mul_epi32(m1, mVec[1]);
             return b * t0 * t1;
 #endif
         }
@@ -1289,7 +1289,7 @@ namespace SIMD {
         UME_FORCE_INLINE int32_t hmax() const {
 #if defined (WA_GCC_INTR_SUPPORT_6_2)
             alignas(64) int32_t raw[16];
-            __m512i t0 = _mm512_max_epu32(mVec[0], mVec[1]);
+            __m512i t0 = _mm512_max_epi32(mVec[0], mVec[1]);
             _mm512_store_si512((__m512i*)raw, t0);
             int32_t t1 = raw[0] > raw[1] ? raw[0] : raw[1];
             int32_t t2 = raw[2] > raw[3] ? raw[2] : raw[3];
@@ -1368,7 +1368,7 @@ namespace SIMD {
         UME_FORCE_INLINE int32_t hmin() const {
 #if defined (WA_GCC_INTR_SUPPORT_6_2)
             alignas(64) int32_t raw[16];
-            __m512i t0 = _mm512_min_epu32(mVec[0], mVec[1]);
+            __m512i t0 = _mm512_min_epi32(mVec[0], mVec[1]);
             _mm512_store_si512((__m512i*)raw, t0);
             int32_t t1 = raw[0] < raw[1] ? raw[0] : raw[1];
             int32_t t2 = raw[2] < raw[3] ? raw[2] : raw[3];
@@ -1385,7 +1385,7 @@ namespace SIMD {
             int32_t t12 = t7 < t8 ? t7 : t8;
 
             int32_t t13 = t9 < t10 ? t9 : t10;
-            int32_t t14 = t10 < t12 ? t11 : t12;
+            int32_t t14 = t11 < t12 ? t11 : t12;
 
             return t13 < t14 ? t13 : t14;
 #else

--- a/plugins/avx512/int/UMESimdVecInt64_16.h
+++ b/plugins/avx512/int/UMESimdVecInt64_16.h
@@ -36,40 +36,6 @@
 
 #include "../../../UMESimdInterface.h"
 
-#define EXPAND_CALL_UNARY(a_256i, unary_op) \
-            _mm512_castsi512_si256( \
-                unary_op( \
-                    _mm512_castsi256_si512(a_256i)))
-
-#define EXPAND_CALL_UNARY_MASK(a_256i, mask8, unary_op) \
-            _mm512_castsi512_si256( \
-                unary_op( \
-                    _mm512_castsi256_si512(a_256i), \
-                    mask8, \
-                    _mm512_castsi256_si512(a_256i)))
-
-#define EXPAND_CALL_BINARY(a_256i, b_256i, binary_op) \
-            _mm512_castsi512_si256( \
-                binary_op( \
-                    _mm512_castsi256_si512(a_256i), \
-                    _mm512_castsi256_si512(b_256i)))
-
-#define EXPAND_CALL_BINARY_MASK(a_256i, b_256i, mask8, binary_op) \
-            _mm512_castsi512_si256( \
-                binary_op( \
-                    _mm512_castsi256_si512(a_256i), \
-                    mask8, \
-                    _mm512_castsi256_si512(a_256i), \
-                    _mm512_castsi256_si512(b_256i)))
-
-#define EXPAND_CALL_BINARY_SCALAR_MASK(a_256i, b_64u, mask8, binary_op) \
-            _mm512_castsi512_si256( \
-                binary_op( \
-                    _mm512_castsi256_si512(a_256i), \
-                    mask8, \
-                    _mm512_castsi256_si512(a_256i), \
-                    _mm512_set1_epi64(b_64u)))
-
 namespace UME {
 namespace SIMD {
 
@@ -2753,13 +2719,6 @@ namespace SIMD {
         // ITOF
         UME_FORCE_INLINE operator SIMDVec_f<double, 16>() const;
     };
-
-#undef SET1_EPI64
-#undef EXPAND_CALL_UNARY
-#undef EXPAND_CALL_UNARY_MASK
-#undef EXPAND_CALL_BINARY
-#undef EXPAND_CALL_BINARY_MASK
-#undef EXPAND_CALL_BINARY_SCALAR_MASK
 
 }
 }

--- a/plugins/avx512/int/UMESimdVecInt64_16.h
+++ b/plugins/avx512/int/UMESimdVecInt64_16.h
@@ -2338,7 +2338,7 @@ namespace SIMD {
             __m512i t3 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
             __m512i t4 = _mm512_setr_epi64(8*stride, 9*stride, 10*stride, 11*stride, 12*stride, 13*stride, 14*stride, 15*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(t3, (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(t4, (const long long int*)baseAddr, 8);
@@ -2362,7 +2362,7 @@ namespace SIMD {
 #endif
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec[0] = _mm512_mask_i64gather_epi64(mVec[0], m0, t3, (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_mask_i64gather_epi64(mVec[1], m1, t4, (const long long int*)baseAddr, 8);
@@ -2376,7 +2376,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(t1, (const long long int*)baseAddr, 8);
@@ -2390,7 +2390,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t2 = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
             __m512i t3 = _mm512_i64gather_epi64(t1, (const long long int*)baseAddr, 8);
@@ -2404,7 +2404,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(indices.mVec[0], (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(indices.mVec[1], (const long long int*)baseAddr, 8);
@@ -2416,7 +2416,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t0 = _mm512_i64gather_epi64(indices.mVec[0], (const long long int*)baseAddr, 8);
             __m512i t1 = _mm512_i64gather_epi64(indices.mVec[1], (const long long int*)baseAddr, 8);
@@ -2440,7 +2440,7 @@ namespace SIMD {
             __m512i t3 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
             __m512i t4 = _mm512_setr_epi64(8*stride, 9*stride, 10*stride, 11*stride, 12*stride, 13*stride, 14*stride, 15*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t3, mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, t4, mVec[1], 8);
@@ -2464,7 +2464,7 @@ namespace SIMD {
 #endif
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, m0, t3, mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, m1, t4, mVec[1], 8);
@@ -2478,7 +2478,7 @@ namespace SIMD {
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t0, mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, t1, mVec[1], 8);
@@ -2492,7 +2492,7 @@ namespace SIMD {
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<16> const & mask, int64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask & 0xFF, t0, mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, ((mask.mMask & 0xFF00) >> 8), t1, mVec[1], 8);
@@ -2504,7 +2504,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, SIMDVec_u<uint64_t, 16> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec[0], mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec[1], mVec[1], 8);
@@ -2516,7 +2516,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<16> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 16> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask & 0xFF, indices.mVec[0], mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, ((mask.mMask & 0xFF00) >> 8), indices.mVec[1], mVec[1], 8);

--- a/plugins/avx512/int/UMESimdVecInt64_16.h
+++ b/plugins/avx512/int/UMESimdVecInt64_16.h
@@ -2372,7 +2372,7 @@ namespace SIMD {
             __m512i t3 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
             __m512i t4 = _mm512_setr_epi64(8*stride, 9*stride, 10*stride, 11*stride, 12*stride, 13*stride, 14*stride, 15*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(t3, (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(t4, (const long long int*)baseAddr, 8);
@@ -2396,7 +2396,7 @@ namespace SIMD {
 #endif
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec[0] = _mm512_mask_i64gather_epi64(mVec[0], m0, t3, (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_mask_i64gather_epi64(mVec[1], m1, t4, (const long long int*)baseAddr, 8);
@@ -2410,7 +2410,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(t1, (const long long int*)baseAddr, 8);
@@ -2424,7 +2424,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t2 = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
             __m512i t3 = _mm512_i64gather_epi64(t1, (const long long int*)baseAddr, 8);
@@ -2438,7 +2438,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(indices.mVec[0], (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(indices.mVec[1], (const long long int*)baseAddr, 8);
@@ -2450,7 +2450,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<16> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 16> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t0 = _mm512_i64gather_epi64(indices.mVec[0], (const long long int*)baseAddr, 8);
             __m512i t1 = _mm512_i64gather_epi64(indices.mVec[1], (const long long int*)baseAddr, 8);
@@ -2474,7 +2474,7 @@ namespace SIMD {
             __m512i t3 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
             __m512i t4 = _mm512_setr_epi64(8*stride, 9*stride, 10*stride, 11*stride, 12*stride, 13*stride, 14*stride, 15*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t3, mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, t4, mVec[1], 8);
@@ -2498,7 +2498,7 @@ namespace SIMD {
 #endif
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, m0, t3, mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, m1, t4, mVec[1], 8);
@@ -2512,7 +2512,7 @@ namespace SIMD {
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t0, mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, t1, mVec[1], 8);
@@ -2526,7 +2526,7 @@ namespace SIMD {
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<16> const & mask, int64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask & 0xFF, t0, mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, ((mask.mMask & 0xFF00) >> 8), t1, mVec[1], 8);
@@ -2538,7 +2538,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, SIMDVec_u<uint64_t, 16> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec[0], mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec[1], mVec[1], 8);
@@ -2550,7 +2550,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<16> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 16> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask & 0xFF, indices.mVec[0], mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, ((mask.mMask & 0xFF00) >> 8), indices.mVec[1], mVec[1], 8);

--- a/plugins/avx512/int/UMESimdVecInt64_16.h
+++ b/plugins/avx512/int/UMESimdVecInt64_16.h
@@ -1502,7 +1502,7 @@ namespace SIMD {
             alignas(64) int64_t raw[8];
             __m512i t0 = _mm512_add_epi64(mVec[0], mVec[1]);
             _mm512_store_si512((__m512i *)raw, t0);
-            return b + raw[0] + raw[1] + raw[2]  + raw[3];
+            return b + raw[0] + raw[1] + raw[2]  + raw[3] + raw[4] + raw[5] + raw[6] + raw[7];
 #else
             int64_t retval = _mm512_reduce_add_epi64(mVec[0]);
             retval += _mm512_reduce_add_epi64(mVec[1]);
@@ -1546,7 +1546,7 @@ namespace SIMD {
             _mm512_store_si512((__m512i *)raw, mVec[0]);
             _mm512_store_si512((__m512i *)(raw + 8), mVec[1]);
             return raw[0] * raw[1] * raw[2]  * raw[3]  * raw[4]  * raw[5]  * raw[6]  * raw[7] *
-                   raw[9] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
+                   raw[8] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
 #else
             int64_t retval = _mm512_reduce_mul_epi64(mVec[0]);
             retval *= _mm512_reduce_mul_epi64(mVec[1]);
@@ -1590,7 +1590,7 @@ namespace SIMD {
             _mm512_store_si512((__m512i *)raw, mVec[0]);
             _mm512_store_si512((__m512i *)(raw + 8), mVec[1]);
             return b * raw[0] * raw[1] * raw[2]  * raw[3]  * raw[4]  * raw[5]  * raw[6]  * raw[7] *
-                   raw[9] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
+                   raw[8] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
 #else
             int64_t retval = _mm512_reduce_mul_epi64(mVec[0]);
             retval *= _mm512_reduce_mul_epi64(mVec[1]);
@@ -1829,7 +1829,7 @@ namespace SIMD {
         UME_FORCE_INLINE int64_t hmin() const {
 #if defined (WA_GCC_INTR_SUPPORT_6_2)
             alignas(64) int64_t raw[8];
-            __m512i t0 = _mm512_min_epu64(mVec[0], mVec[1]);
+            __m512i t0 = _mm512_min_epi64(mVec[0], mVec[1]);
             _mm512_store_si512((__m512i *)raw, t0);
             int64_t t1 = raw[0] < raw[1] ? raw[0] : raw[1];
             int64_t t2 = raw[2] < raw[3] ? raw[2] : raw[3];

--- a/plugins/avx512/int/UMESimdVecInt64_2.h
+++ b/plugins/avx512/int/UMESimdVecInt64_2.h
@@ -1729,7 +1729,7 @@ namespace SIMD {
         // GATHERU
         UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1740,7 +1740,7 @@ namespace SIMD {
         // MGATHERU
         UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m128i t1 = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1760,7 +1760,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 =_mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1771,7 +1771,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m128i t1 = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1790,7 +1790,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1800,7 +1800,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m128i t0 = _mm_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1820,7 +1820,7 @@ namespace SIMD {
         // SCATTERU
         UME_FORCE_INLINE int64_t* scatteru(int64_t* baseAddr, uint64_t stride) const {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
@@ -1849,7 +1849,7 @@ namespace SIMD {
         // MSCATTERU
         UME_FORCE_INLINE int64_t*  scatteru(SIMDVecMask<2> const & mask, int64_t* baseAddr, uint64_t stride) const {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -1878,7 +1878,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, uint64_t* indices) const {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
@@ -1907,7 +1907,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<2> const & mask, int64_t* baseAddr, uint64_t* indices) const {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -1935,7 +1935,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, SIMDVec_u<uint64_t, 2> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
@@ -1963,7 +1963,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<2> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 2> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);

--- a/plugins/avx512/int/UMESimdVecInt64_2.h
+++ b/plugins/avx512/int/UMESimdVecInt64_2.h
@@ -1729,7 +1729,7 @@ namespace SIMD {
         // GATHERU
         UME_FORCE_INLINE SIMDVec_i & gatheru(int64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1740,7 +1740,7 @@ namespace SIMD {
         // MGATHERU
         UME_FORCE_INLINE SIMDVec_i & gatheru(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m128i t1 = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1760,7 +1760,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 =_mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1771,7 +1771,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m128i t1 = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1790,7 +1790,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1800,7 +1800,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 2> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m128i t0 = _mm_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1820,7 +1820,7 @@ namespace SIMD {
         // SCATTERU
         UME_FORCE_INLINE int64_t* scatteru(int64_t* baseAddr, uint64_t stride) const {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
@@ -1849,7 +1849,7 @@ namespace SIMD {
         // MSCATTERU
         UME_FORCE_INLINE int64_t*  scatteru(SIMDVecMask<2> const & mask, int64_t* baseAddr, uint64_t stride) const {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -1878,7 +1878,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, uint64_t* indices) const {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
@@ -1907,7 +1907,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<2> const & mask, int64_t* baseAddr, uint64_t* indices) const {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -1935,7 +1935,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, SIMDVec_u<uint64_t, 2> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
@@ -1963,7 +1963,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<2> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 2> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);

--- a/plugins/avx512/int/UMESimdVecInt64_4.h
+++ b/plugins/avx512/int/UMESimdVecInt64_4.h
@@ -1816,7 +1816,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, t2, 8);
 #else
@@ -1833,7 +1833,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m256i t3 = _mm256_i64gather_epi64((const long long int*)baseAddr, t2, 8);
 #else
@@ -1853,7 +1853,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 =_mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1864,7 +1864,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m256i t1 = _mm256_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1883,7 +1883,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1893,7 +1893,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m256i t0 = _mm256_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1919,7 +1919,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_i64scatter_epi64((long long int*)baseAddr, t2, mVec, 8);
@@ -1948,7 +1948,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t2, mVec, 8);
@@ -1971,7 +1971,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, uint64_t* indices) const {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
@@ -2000,7 +2000,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<4> const & mask, int64_t* baseAddr, uint64_t* indices) const {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -2028,7 +2028,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, SIMDVec_u<uint64_t, 4> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
@@ -2056,7 +2056,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<4> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 4> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);

--- a/plugins/avx512/int/UMESimdVecInt64_4.h
+++ b/plugins/avx512/int/UMESimdVecInt64_4.h
@@ -1816,7 +1816,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, t2, 8);
 #else
@@ -1833,7 +1833,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m256i t3 = _mm256_i64gather_epi64((const long long int*)baseAddr, t2, 8);
 #else
@@ -1853,7 +1853,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 =_mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1864,7 +1864,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m256i t1 = _mm256_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1883,7 +1883,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1893,7 +1893,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<4> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 4> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m256i t0 = _mm256_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1919,7 +1919,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_i64scatter_epi64((long long int*)baseAddr, t2, mVec, 8);
@@ -1948,7 +1948,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t2, mVec, 8);
@@ -1971,7 +1971,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, uint64_t* indices) const {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
@@ -2000,7 +2000,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<4> const & mask, int64_t* baseAddr, uint64_t* indices) const {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -2028,7 +2028,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, SIMDVec_u<uint64_t, 4> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
@@ -2056,7 +2056,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<4> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 4> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);

--- a/plugins/avx512/int/UMESimdVecInt64_8.h
+++ b/plugins/avx512/int/UMESimdVecInt64_8.h
@@ -1680,7 +1680,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(t2, (const long long int*)baseAddr, 8);
 #else
@@ -1697,7 +1697,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t3 = _mm512_i64gather_epi64(t2, (const long long int*)baseAddr, 8);
 #else
@@ -1709,7 +1709,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 =_mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
 #else
@@ -1720,7 +1720,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t1 = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
 #else
@@ -1731,7 +1731,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(indices.mVec, (const long long int*)baseAddr, 8);
 #else
@@ -1741,7 +1741,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t0 = _mm512_i64gather_epi64(indices.mVec, (const long long int*)baseAddr, 8);
 #else
@@ -1759,7 +1759,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t2, mVec, 8);
 #else
@@ -1776,7 +1776,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t2, mVec, 8);
 #else
@@ -1787,7 +1787,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
 #else
@@ -1798,7 +1798,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<8> const & mask, int64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
 #else
@@ -1808,7 +1808,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, SIMDVec_u<uint64_t, 8> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
 #else
@@ -1818,7 +1818,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<8> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 8> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);
 #else

--- a/plugins/avx512/int/UMESimdVecInt64_8.h
+++ b/plugins/avx512/int/UMESimdVecInt64_8.h
@@ -36,40 +36,6 @@
 
 #include "../../../UMESimdInterface.h"
 
-#define EXPAND_CALL_UNARY(a_256i, unary_op) \
-            _mm512_castsi512_si256( \
-                unary_op( \
-                    _mm512_castsi256_si512(a_256i)))
-
-#define EXPAND_CALL_UNARY_MASK(a_256i, mask8, unary_op) \
-            _mm512_castsi512_si256( \
-                unary_op( \
-                    _mm512_castsi256_si512(a_256i), \
-                    mask8, \
-                    _mm512_castsi256_si512(a_256i)))
-
-#define EXPAND_CALL_BINARY(a_256i, b_256i, binary_op) \
-            _mm512_castsi512_si256( \
-                binary_op( \
-                    _mm512_castsi256_si512(a_256i), \
-                    _mm512_castsi256_si512(b_256i)))
-
-#define EXPAND_CALL_BINARY_MASK(a_256i, b_256i, mask8, binary_op) \
-            _mm512_castsi512_si256( \
-                binary_op( \
-                    _mm512_castsi256_si512(a_256i), \
-                    mask8, \
-                    _mm512_castsi256_si512(a_256i), \
-                    _mm512_castsi256_si512(b_256i)))
-
-#define EXPAND_CALL_BINARY_SCALAR_MASK(a_256i, b_64u, mask8, binary_op) \
-            _mm512_castsi512_si256( \
-                binary_op( \
-                    _mm512_castsi256_si512(a_256i), \
-                    mask8, \
-                    _mm512_castsi256_si512(a_256i), \
-                    _mm512_set1_epi64(b_64u)))
-
 namespace UME {
 namespace SIMD {
 
@@ -2060,13 +2026,6 @@ namespace SIMD {
         // ITOF
         UME_FORCE_INLINE operator SIMDVec_f<double, 8>() const;
     };
-
-#undef SET1_EPI64
-#undef EXPAND_CALL_UNARY
-#undef EXPAND_CALL_UNARY_MASK
-#undef EXPAND_CALL_BINARY
-#undef EXPAND_CALL_BINARY_MASK
-#undef EXPAND_CALL_BINARY_SCALAR_MASK
 
 }
 }

--- a/plugins/avx512/int/UMESimdVecInt64_8.h
+++ b/plugins/avx512/int/UMESimdVecInt64_8.h
@@ -1714,7 +1714,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(t2, (const long long int*)baseAddr, 8);
 #else
@@ -1731,7 +1731,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t3 = _mm512_i64gather_epi64(t2, (const long long int*)baseAddr, 8);
 #else
@@ -1743,7 +1743,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 =_mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
 #else
@@ -1754,7 +1754,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t1 = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
 #else
@@ -1765,7 +1765,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(int64_t const * baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(indices.mVec, (const long long int*)baseAddr, 8);
 #else
@@ -1775,7 +1775,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<8> const & mask, int64_t const * baseAddr, SIMDVec_u<uint64_t, 8> const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t0 = _mm512_i64gather_epi64(indices.mVec, (const long long int*)baseAddr, 8);
 #else
@@ -1793,7 +1793,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t2, mVec, 8);
 #else
@@ -1810,7 +1810,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t2, mVec, 8);
 #else
@@ -1821,7 +1821,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
 #else
@@ -1832,7 +1832,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<8> const & mask, int64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
 #else
@@ -1842,7 +1842,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE int64_t* scatter(int64_t* baseAddr, SIMDVec_u<uint64_t, 8> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
 #else
@@ -1852,7 +1852,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE int64_t* scatter(SIMDVecMask<8> const & mask, int64_t* baseAddr, SIMDVec_u<uint64_t, 8> const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);
 #else

--- a/plugins/avx512/uint/UMESimdVecUint32_16.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_16.h
@@ -808,7 +808,7 @@ namespace SIMD {
             alignas(64) uint32_t raw[16];
             _mm512_store_si512((__m512i*)raw, mVec);
             return b + raw[0] + raw[1] + raw[2]  + raw[3]  + raw[4]  + raw[5]  + raw[6]  + raw[7] +
-                   raw[9] + raw[9] + raw[10] + raw[11] + raw[12] + raw[13] + raw[14] + raw[15];
+                   raw[8] + raw[9] + raw[10] + raw[11] + raw[12] + raw[13] + raw[14] + raw[15];
 #else
             uint32_t retval = _mm512_reduce_add_epi32(mVec);
             return retval + b;
@@ -838,7 +838,7 @@ namespace SIMD {
             if (mask.mMask & 0x8000) t0 += raw[15];
             return t0;
 #else
-            uint32_t retval = _mm512_mask_reduce_add_epi32(mask.mMask, mVec);
+            uint32_t retval = (uint32_t) _mm512_mask_reduce_add_epi32(mask.mMask, mVec);
             return retval + b;
 #endif
         }
@@ -848,9 +848,9 @@ namespace SIMD {
             alignas(64) uint32_t raw[16];
             _mm512_store_si512((__m512i*)raw, mVec);
             return raw[0] * raw[1] * raw[2]  * raw[3]  * raw[4]  * raw[5]  * raw[6]  * raw[7] *
-                   raw[9] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
+                   raw[8] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
 #else
-            uint32_t retval = _mm512_reduce_mul_epi32(mVec);
+            uint32_t retval = (uint32_t) _mm512_reduce_mul_epi32(mVec);
             return retval;
 #endif
         }
@@ -888,10 +888,10 @@ namespace SIMD {
             alignas(64) uint32_t raw[16];
             _mm512_store_si512((__m512i*)raw, mVec);
             return b * raw[0] * raw[1] * raw[2]  * raw[3]  * raw[4]  * raw[5]  * raw[6]  * raw[7] *
-                   raw[9] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
+                   raw[8] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
 #else
             uint32_t retval = b;
-            retval *= _mm512_reduce_mul_epi32(mVec);
+            retval *= (uint32_t) _mm512_reduce_mul_epi32(mVec);
             return retval;
 #endif
         }

--- a/plugins/avx512/uint/UMESimdVecUint32_32.h
+++ b/plugins/avx512/uint/UMESimdVecUint32_32.h
@@ -1040,8 +1040,8 @@ namespace SIMD {
 #else
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             __mmask16 m1 = (mask.mMask & 0xFFFF0000) >> 16;
-            uint32_t t0 = _mm512_mask_reduce_add_epi32(m0, mVec[0]);
-            uint32_t t1 = _mm512_mask_reduce_add_epi32(m1, mVec[1]);
+            uint32_t t0 = _mm512_mask_reduce_mul_epi32(m0, mVec[0]);
+            uint32_t t1 = _mm512_mask_reduce_mul_epi32(m1, mVec[1]);
             return t0 * t1;
 #endif
         }
@@ -1102,8 +1102,8 @@ namespace SIMD {
 #else
             __mmask16 m0 = mask.mMask & 0x0000FFFF;
             __mmask16 m1 = (mask.mMask & 0xFFFF0000) >> 16;
-            uint32_t t0 = _mm512_mask_reduce_add_epi32(m0, mVec[0]);
-            uint32_t t1 = _mm512_mask_reduce_add_epi32(m1, mVec[1]);
+            uint32_t t0 = _mm512_mask_reduce_mul_epi32(m0, mVec[0]);
+            uint32_t t1 = _mm512_mask_reduce_mul_epi32(m1, mVec[1]);
             return b * t0 * t1;
 #endif
         }
@@ -1399,7 +1399,7 @@ namespace SIMD {
             uint32_t t12 = t7 < t8 ? t7 : t8;
 
             uint32_t t13 = t9 < t10 ? t9 : t10;
-            uint32_t t14 = t10 < t12 ? t11 : t12;
+            uint32_t t14 = t11 < t12 ? t11 : t12;
 
             return t13 < t14 ? t13 : t14;
 #else

--- a/plugins/avx512/uint/UMESimdVecUint64_16.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_16.h
@@ -1993,7 +1993,7 @@ namespace SIMD {
             __m512i t3 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
             __m512i t4 = _mm512_setr_epi64(8*stride, 9*stride, 10*stride, 11*stride, 12*stride, 13*stride, 14*stride, 15*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(t3, (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(t4, (const long long int*)baseAddr, 8);
@@ -2017,7 +2017,7 @@ namespace SIMD {
 #endif
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t5 = _mm512_i64gather_epi64(t3, (const long long int*)baseAddr, 8);
             __m512i t6 = _mm512_i64gather_epi64(t4, (const long long int*)baseAddr, 8);
@@ -2033,7 +2033,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 =_mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(t1, (const long long int*)baseAddr, 8);
@@ -2049,7 +2049,7 @@ namespace SIMD {
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
             __m512i t2 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t3 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t4 = _mm512_i64gather_epi64(t2, (const long long int*)baseAddr, 8);
             __m512i t5 = _mm512_i64gather_epi64(t3, (const long long int*)baseAddr, 8);
@@ -2063,7 +2063,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(indices.mVec[0], (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(indices.mVec[1], (const long long int*)baseAddr, 8);
@@ -2077,7 +2077,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             __mmask8 t0 = mask.mMask & 0x00FF;
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t2 = _mm512_i64gather_epi64(indices.mVec[0], (const long long int*)baseAddr, 8);
             __m512i t3 = _mm512_i64gather_epi64(indices.mVec[1], (const long long int*)baseAddr, 8);
@@ -2101,7 +2101,7 @@ namespace SIMD {
             __m512i t3 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
             __m512i t4 = _mm512_setr_epi64(8*stride, 9*stride, 10*stride, 11*stride, 12*stride, 13*stride, 14*stride, 15*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t3, mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, t4, mVec[1], 8);
@@ -2125,7 +2125,7 @@ namespace SIMD {
 #endif
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, m0, t3, mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, m1, t4, mVec[1], 8);
@@ -2139,7 +2139,7 @@ namespace SIMD {
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t0, mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, t1, mVec[1], 8);
@@ -2155,7 +2155,7 @@ namespace SIMD {
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
             __m512i t2 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t3 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, t0, t2, mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, t1, t3, mVec[1], 8);
@@ -2167,7 +2167,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec[0], mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec[1], mVec[1], 8);
@@ -2181,7 +2181,7 @@ namespace SIMD {
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<16> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) const {
             __mmask8 t0 = mask.mMask & 0x00FF;
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, t0, indices.mVec[0], mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, t1, indices.mVec[1], mVec[1], 8);

--- a/plugins/avx512/uint/UMESimdVecUint64_16.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_16.h
@@ -1048,8 +1048,8 @@ namespace SIMD {
             _mm512_store_si512((__m512i *)raw, t0);
             return raw[0] + raw[1] + raw[2]  + raw[3]  + raw[4]  + raw[5]  + raw[6]  + raw[7];
 #else
-            uint64_t retval = _mm512_reduce_add_epi64(mVec[0]);
-            retval += _mm512_reduce_add_epi64(mVec[1]);
+            __m512i t0 = _mm512_add_epi64(mVec[0], mVec[1]);
+            uint64_t retval = _mm512_reduce_add_epi64(t0);
             return retval;
 #endif
         }
@@ -1089,9 +1089,10 @@ namespace SIMD {
             alignas(64) uint64_t raw[8];
             __m512i t0 = _mm512_add_epi64(mVec[0], mVec[1]);
             _mm512_store_si512((__m512i *)raw, t0);
-            return b + raw[0] + raw[1] + raw[2]  + raw[3];
+            return b + raw[0] + raw[1] + raw[2]  + raw[3] + raw[4] + raw[5] + raw[6] + raw[7];
 #else
-            uint64_t retval = _mm512_reduce_add_epi64(mVec[0]);
+            __m512i t0 = _mm512_add_epi64(mVec[0], mVec[1]);
+            uint64_t retval = _mm512_reduce_add_epi64(t0);
             return retval + b;
 #endif
         }
@@ -1120,7 +1121,8 @@ namespace SIMD {
             if (mask.mMask & 0x8000) t0 += raw[15];
             return t0;
 #else
-            uint64_t retval = _mm512_mask_reduce_add_epi64(mask.mMask, mVec[0]);
+	    uint64_t retval = _mm512_mask_reduce_add_epi64(mask.mMask & 0xFF, mVec[0]);
+            retval += _mm512_mask_reduce_add_epi64((mask.mMask & 0xFF00) >> 8, mVec[1]);
             return retval + b;
 #endif
         }
@@ -1131,7 +1133,7 @@ namespace SIMD {
             _mm512_store_si512((__m512i *)raw, mVec[0]);
             _mm512_store_si512((__m512i *)(raw + 8), mVec[1]);
             return raw[0] * raw[1] * raw[2]  * raw[3]  * raw[4]  * raw[5]  * raw[6]  * raw[7] *
-                   raw[9] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
+                   raw[8] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
 #else
             uint64_t retval = _mm512_reduce_mul_epi64(mVec[0]);
             retval *= _mm512_reduce_mul_epi64(mVec[1]);
@@ -1177,7 +1179,7 @@ namespace SIMD {
             _mm512_store_si512((__m512i *)raw, mVec[0]);
             _mm512_store_si512((__m512i *)(raw + 8), mVec[1]);
             return b * raw[0] * raw[1] * raw[2]  * raw[3]  * raw[4]  * raw[5]  * raw[6]  * raw[7] *
-                   raw[9] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
+                   raw[8] * raw[9] * raw[10] * raw[11] * raw[12] * raw[13] * raw[14] * raw[15];
 #else
             uint64_t retval = _mm512_reduce_mul_epi64(mVec[0]);
             retval *= _mm512_reduce_mul_epi64(mVec[1]);

--- a/plugins/avx512/uint/UMESimdVecUint64_16.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_16.h
@@ -36,28 +36,6 @@
 
 #include "../../../UMESimdInterface.h"
 
-#define EXPAND_CALL_BINARY(a_512i, b_512i, binary_op) \
-            _mm512_castsi512_si512( \
-                binary_op( \
-                    _mm512_castsi512_si512(a_512i), \
-                    _mm512_castsi512_si512(b_512i)))
-
-#define EXPAND_CALL_BINARY_MASK(a_512i, b_512i, mask8, binary_op) \
-            _mm512_castsi512_si512( \
-                binary_op( \
-                    _mm512_castsi512_si512(a_512i), \
-                    mask8, \
-                    _mm512_castsi512_si512(a_512i), \
-                    _mm512_castsi512_si512(b_512i)))
-
-#define EXPAND_CALL_BINARY_SCALAR_MASK(a_512i, b_64u, mask8, binary_op) \
-            _mm512_castsi512_si512( \
-                binary_op( \
-                    _mm512_castsi512_si512(a_512i), \
-                    mask8, \
-                    _mm512_castsi512_si512(a_512i), \
-                    _mm512__mm512_set1_epi64(b_64u)))
-
 namespace UME {
 namespace SIMD {
 
@@ -2368,11 +2346,6 @@ namespace SIMD {
         // UTOF
         UME_FORCE_INLINE operator SIMDVec_f<double, 16>() const;
     };
-
-#undef _mm512_set1_epi64
-#undef EXPAND_CALL_BINARY
-#undef EXPAND_CALL_BINARY_MASK
-#undef EXPAND_CALL_BINARY_SCALAR_MASK
 
 }
 }

--- a/plugins/avx512/uint/UMESimdVecUint64_16.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_16.h
@@ -1974,7 +1974,7 @@ namespace SIMD {
             __m512i t3 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
             __m512i t4 = _mm512_setr_epi64(8*stride, 9*stride, 10*stride, 11*stride, 12*stride, 13*stride, 14*stride, 15*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(t3, (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(t4, (const long long int*)baseAddr, 8);
@@ -1998,7 +1998,7 @@ namespace SIMD {
 #endif
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t5 = _mm512_i64gather_epi64(t3, (const long long int*)baseAddr, 8);
             __m512i t6 = _mm512_i64gather_epi64(t4, (const long long int*)baseAddr, 8);
@@ -2014,7 +2014,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 =_mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(t1, (const long long int*)baseAddr, 8);
@@ -2030,7 +2030,7 @@ namespace SIMD {
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
             __m512i t2 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t3 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t4 = _mm512_i64gather_epi64(t2, (const long long int*)baseAddr, 8);
             __m512i t5 = _mm512_i64gather_epi64(t3, (const long long int*)baseAddr, 8);
@@ -2044,7 +2044,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec[0] = _mm512_i64gather_epi64(indices.mVec[0], (const long long int*)baseAddr, 8);
             mVec[1] = _mm512_i64gather_epi64(indices.mVec[1], (const long long int*)baseAddr, 8);
@@ -2058,7 +2058,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<16> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
             __mmask8 t0 = mask.mMask & 0x00FF;
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t2 = _mm512_i64gather_epi64(indices.mVec[0], (const long long int*)baseAddr, 8);
             __m512i t3 = _mm512_i64gather_epi64(indices.mVec[1], (const long long int*)baseAddr, 8);
@@ -2082,7 +2082,7 @@ namespace SIMD {
             __m512i t3 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
             __m512i t4 = _mm512_setr_epi64(8*stride, 9*stride, 10*stride, 11*stride, 12*stride, 13*stride, 14*stride, 15*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t3, mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, t4, mVec[1], 8);
@@ -2106,7 +2106,7 @@ namespace SIMD {
 #endif
             __mmask8 m0 = mask.mMask & 0x00FF;
             __mmask8 m1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, m0, t3, mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, m1, t4, mVec[1], 8);
@@ -2120,7 +2120,7 @@ namespace SIMD {
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t1 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t0, mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, t1, mVec[1], 8);
@@ -2136,7 +2136,7 @@ namespace SIMD {
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
             __m512i t2 = _mm512_loadu_si512((__m512i *)indices);
             __m512i t3 = _mm512_loadu_si512((__m512i *)(indices + 8));
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, t0, t2, mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, t1, t3, mVec[1], 8);
@@ -2148,7 +2148,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec[0], mVec[0], 8);
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec[1], mVec[1], 8);
@@ -2162,7 +2162,7 @@ namespace SIMD {
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<16> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) const {
             __mmask8 t0 = mask.mMask & 0x00FF;
             __mmask8 t1 = (mask.mMask & 0xFF00) >> 8;
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, t0, indices.mVec[0], mVec[0], 8);
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, t1, indices.mVec[1], mVec[1], 8);

--- a/plugins/avx512/uint/UMESimdVecUint64_2.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_2.h
@@ -1724,7 +1724,7 @@ namespace SIMD {
         // MGATHERU
         UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m128i t1 = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1744,7 +1744,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 =_mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1755,7 +1755,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m128i t1 = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1774,7 +1774,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1784,7 +1784,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m128i t0 = _mm_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1804,7 +1804,7 @@ namespace SIMD {
         // SCATTERU
         UME_FORCE_INLINE uint64_t* scatteru(uint64_t* baseAddr, uint64_t stride) const {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*) baseAddr, t0, mVec, 8);
   #else
@@ -1833,7 +1833,7 @@ namespace SIMD {
         // MSCATTERU
         UME_FORCE_INLINE uint64_t*  scatteru(SIMDVecMask<2> const & mask, uint64_t* baseAddr, uint64_t stride) const {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -1862,7 +1862,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, uint64_t* indices) const {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
@@ -1891,7 +1891,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<2> const & mask, uint64_t* baseAddr, uint64_t* indices) const {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
     #if defined(__AVX512VL__)
                 _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -1919,7 +1919,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
@@ -1947,7 +1947,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<2> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);

--- a/plugins/avx512/uint/UMESimdVecUint64_2.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_2.h
@@ -1713,7 +1713,7 @@ namespace SIMD {
         // GATHERU
         UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1724,7 +1724,7 @@ namespace SIMD {
         // MGATHERU
         UME_FORCE_INLINE SIMDVec_u & gatheru(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m128i t1 = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1744,7 +1744,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 =_mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1755,7 +1755,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m128i t1 = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1774,7 +1774,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1784,7 +1784,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m128i t0 = _mm_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1804,7 +1804,7 @@ namespace SIMD {
         // SCATTERU
         UME_FORCE_INLINE uint64_t* scatteru(uint64_t* baseAddr, uint64_t stride) const {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*) baseAddr, t0, mVec, 8);
   #else
@@ -1833,7 +1833,7 @@ namespace SIMD {
         // MSCATTERU
         UME_FORCE_INLINE uint64_t*  scatteru(SIMDVecMask<2> const & mask, uint64_t* baseAddr, uint64_t stride) const {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -1862,7 +1862,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, uint64_t* indices) const {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
@@ -1891,7 +1891,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<2> const & mask, uint64_t* baseAddr, uint64_t* indices) const {
             __m128i t0 = _mm_loadu_si128((__m128i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
     #if defined(__AVX512VL__)
                 _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -1919,7 +1919,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
@@ -1947,7 +1947,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<2> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);

--- a/plugins/avx512/uint/UMESimdVecUint64_2.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_2.h
@@ -1713,7 +1713,7 @@ namespace SIMD {
         // GATHERU
         UME_FORCE_INLINE SIMDVec_u & gatheru(uint64_t const * baseAddr, uint64_t stride) {
             __m128i t0 = _mm_set_epi64x(stride, 0);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else

--- a/plugins/avx512/uint/UMESimdVecUint64_4.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_4.h
@@ -1802,7 +1802,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, t2, 8);
 #else
@@ -1819,7 +1819,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m256i t3 = _mm256_i64gather_epi64((const long long int*)baseAddr, t2, 8);
 #else
@@ -1839,7 +1839,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 =_mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1850,7 +1850,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m256i t1 = _mm256_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1869,7 +1869,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1879,7 +1879,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m256i t0 = _mm256_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1906,7 +1906,7 @@ namespace SIMD {
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
 
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_i64scatter_epi64((long long int*)baseAddr, t2, mVec, 8);
@@ -1935,7 +1935,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t2, mVec, 8);
@@ -1958,7 +1958,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, uint64_t* indices) const {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
     #if defined(__AVX512VL__)
                 _mm256_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
@@ -1987,7 +1987,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<4> const & mask, uint64_t* baseAddr, uint64_t* indices) const {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -2015,7 +2015,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
@@ -2043,7 +2043,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<4> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);

--- a/plugins/avx512/uint/UMESimdVecUint64_4.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_4.h
@@ -1802,7 +1802,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, t2, 8);
 #else
@@ -1819,7 +1819,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m256i t3 = _mm256_i64gather_epi64((const long long int*)baseAddr, t2, 8);
 #else
@@ -1839,7 +1839,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 =_mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1850,7 +1850,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m256i t1 = _mm256_i64gather_epi64((const long long int*)baseAddr, t0, 8);
 #else
@@ -1879,7 +1879,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<4> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m256i t0 = _mm256_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else
@@ -1906,7 +1906,7 @@ namespace SIMD {
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
 
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_i64scatter_epi64((long long int*)baseAddr, t2, mVec, 8);
@@ -1935,7 +1935,7 @@ namespace SIMD {
 #else
             __m256i t2 = _mm256_setr_epi64x(0, stride, 2*stride, 3*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t2, mVec, 8);
@@ -1958,7 +1958,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, uint64_t* indices) const {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
     #if defined(__AVX512VL__)
                 _mm256_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
@@ -1987,7 +1987,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<4> const & mask, uint64_t* baseAddr, uint64_t* indices) const {
             __m256i t0 = _mm256_loadu_si256((__m256i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
@@ -2015,7 +2015,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
@@ -2043,7 +2043,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<4> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2)  || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
   #if defined(__AVX512VL__)
             _mm256_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);

--- a/plugins/avx512/uint/UMESimdVecUint64_4.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_4.h
@@ -1869,7 +1869,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm256_i64gather_epi64((const long long int*)baseAddr, indices.mVec, 8);
 #else

--- a/plugins/avx512/uint/UMESimdVecUint64_8.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_8.h
@@ -1733,7 +1733,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(t2, (const long long int*)baseAddr, 8);
 #else
@@ -1750,7 +1750,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t3 = _mm512_i64gather_epi64(t2, (const long long int*)baseAddr, 8);
 #else
@@ -1762,7 +1762,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 =_mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
 #else
@@ -1773,7 +1773,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t1 = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
 #else
@@ -1784,7 +1784,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(indices.mVec, (const long long int*)baseAddr, 8);
 #else
@@ -1794,7 +1794,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             __m512i t0 = _mm512_i64gather_epi64(indices.mVec, (const long long int*)baseAddr, 8);
 #else
@@ -1812,7 +1812,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t2, mVec, 8);
 #else
@@ -1829,7 +1829,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t2, mVec, 8);
 #else
@@ -1840,7 +1840,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
 #else
@@ -1851,7 +1851,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<8> const & mask, uint64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
 #else
@@ -1861,7 +1861,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
 #else
@@ -1871,7 +1871,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<8> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_2)
+#if defined(WA_GCC_INTR_SUPPORT_6_2) || defined(WA_GCC_INTR_SUPPORT_7)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);
 #else

--- a/plugins/avx512/uint/UMESimdVecUint64_8.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_8.h
@@ -1277,7 +1277,7 @@ namespace SIMD {
         }
         // MIMAX
         UME_FORCE_INLINE uint32_t imax(SIMDVecMask<8> const & mask) const {
-            uint64_t t0 = hmax();
+            uint64_t t0 = hmax(mask);
             __m512i t1 = _mm512_set1_epi64(t0);
             __mmask8 t2 = _mm512_cmp_epu64_mask(mVec, t1, _MM_CMPINT_EQ);
             // De Brujin number is: 00011101
@@ -1343,7 +1343,7 @@ namespace SIMD {
         }
         // MIMIN
         UME_FORCE_INLINE uint32_t imin(SIMDVecMask<8> const & mask) const {
-            uint64_t t0 = hmin();
+            uint64_t t0 = hmin(mask);
             __m512i t1 = _mm512_set1_epi64(t0);
             __mmask8 t2 = _mm512_cmp_epu64_mask(mVec, t1, _MM_CMPINT_EQ);
             // De Brujin number is: 00011101

--- a/plugins/avx512/uint/UMESimdVecUint64_8.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_8.h
@@ -36,28 +36,6 @@
 
 #include "../../../UMESimdInterface.h"
 
-#define EXPAND_CALL_BINARY(a_512i, b_512i, binary_op) \
-            _mm512_castsi512_si512( \
-                binary_op( \
-                    _mm512_castsi512_si512(a_512i), \
-                    _mm512_castsi512_si512(b_512i)))
-
-#define EXPAND_CALL_BINARY_MASK(a_512i, b_512i, mask8, binary_op) \
-            _mm512_castsi512_si512( \
-                binary_op( \
-                    _mm512_castsi512_si512(a_512i), \
-                    mask8, \
-                    _mm512_castsi512_si512(a_512i), \
-                    _mm512_castsi512_si512(b_512i)))
-
-#define EXPAND_CALL_BINARY_SCALAR_MASK(a_512i, b_64u, mask8, binary_op) \
-            _mm512_castsi512_si512( \
-                binary_op( \
-                    _mm512_castsi512_si512(a_512i), \
-                    mask8, \
-                    _mm512_castsi512_si512(a_512i), \
-                    _mm512__mm512_set1_epi64(b_64u)))
-
 namespace UME {
 namespace SIMD {
 
@@ -2043,11 +2021,6 @@ namespace SIMD {
         // UTOF
         UME_FORCE_INLINE operator SIMDVec_f<double, 8>() const;
     };
-
-#undef _mm512_set1_epi64
-#undef EXPAND_CALL_BINARY
-#undef EXPAND_CALL_BINARY_MASK
-#undef EXPAND_CALL_BINARY_SCALAR_MASK
 
 }
 }

--- a/plugins/avx512/uint/UMESimdVecUint64_8.h
+++ b/plugins/avx512/uint/UMESimdVecUint64_8.h
@@ -1711,7 +1711,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(t2, (const long long int*)baseAddr, 8);
 #else
@@ -1728,7 +1728,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t3 = _mm512_i64gather_epi64(t2, (const long long int*)baseAddr, 8);
 #else
@@ -1740,7 +1740,7 @@ namespace SIMD {
         // GATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 =_mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
 #else
@@ -1751,7 +1751,7 @@ namespace SIMD {
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint64_t const * baseAddr, uint64_t const * indices) {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t1 = _mm512_i64gather_epi64(t0, (const long long int*)baseAddr, 8);
 #else
@@ -1762,7 +1762,7 @@ namespace SIMD {
         }
         // GATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             mVec = _mm512_i64gather_epi64(indices.mVec, (const long long int*)baseAddr, 8);
 #else
@@ -1772,7 +1772,7 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<8> const & mask, uint64_t const * baseAddr, SIMDVec_u const & indices) {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             __m512i t0 = _mm512_i64gather_epi64(indices.mVec, (const long long int*)baseAddr, 8);
 #else
@@ -1790,7 +1790,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t2, mVec, 8);
 #else
@@ -1807,7 +1807,7 @@ namespace SIMD {
 #else
             __m512i t2 = _mm512_setr_epi64(0, stride, 2*stride, 3*stride, 4*stride, 5*stride, 6*stride, 7*stride);
 #endif
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t2, mVec, 8);
 #else
@@ -1818,7 +1818,7 @@ namespace SIMD {
         // SCATTERS
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, t0, mVec, 8);
 #else
@@ -1829,7 +1829,7 @@ namespace SIMD {
         // MSCATTERS
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<8> const & mask, uint64_t* baseAddr, uint64_t* indices) const {
             __m512i t0 = _mm512_loadu_si512((__m512i *)indices);
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, t0, mVec, 8);
 #else
@@ -1839,7 +1839,7 @@ namespace SIMD {
         }
         // SCATTERV
         UME_FORCE_INLINE uint64_t* scatter(uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_i64scatter_epi64((long long int*)baseAddr, indices.mVec, mVec, 8);
 #else
@@ -1849,7 +1849,7 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE uint64_t* scatter(SIMDVecMask<8> const & mask, uint64_t* baseAddr, SIMDVec_u const & indices) const {
-#if defined(WA_GCC_INTR_SUPPORT_6_4) || defined(WA_GCC_INTR_SUPPORT_7_1)
+#if defined(WA_GCC_INTR_SUPPORT_7_1)
             // g++ has some interface issues.
             _mm512_mask_i64scatter_epi64((long long int*)baseAddr, mask.mMask, indices.mVec, mVec, 8);
 #else

--- a/unittest/Makefile
+++ b/unittest/Makefile
@@ -6,9 +6,6 @@
 # {FORCE_SCALAR_PLUGIN=ON}
 
 CXXFLAGS=-std=c++11
-CXX=g++
-ISA=mic_avx512
-BUILD=release
 
 ifneq (,$(findstring armclang,$(CXX)))
 	CXXCOMPILER=armclang++
@@ -29,8 +26,7 @@ endif
 #some predefined rules
 ifeq ($(CXXCOMPILER), g++)
 	COMPILER_PREFIX=gcc
-#-W -Wall
-	CXXFLAGS+=-W -Wall -pedantic -fstrict-aliasing -Wstrict-aliasing -Woverflow
+	CXXFLAGS+=-W -Wall -pedantic -fstrict-aliasing -Wstrict-aliasing -Woverflow -Werror
 endif
 ifeq ($(CXXCOMPILER), clang++)
 	COMPILER_PREFIX=clang

--- a/unittest/Makefile
+++ b/unittest/Makefile
@@ -5,7 +5,7 @@
 # {FORCE_OPENMP_PLUGIN=ON}
 # {FORCE_SCALAR_PLUGIN=ON}
 
-CXXFLAGS=-std=c++14
+CXXFLAGS=-std=c++11
 CXX=g++
 ISA=mic_avx512
 BUILD=release
@@ -30,7 +30,7 @@ endif
 ifeq ($(CXXCOMPILER), g++)
 	COMPILER_PREFIX=gcc
 #-W -Wall
-	CXXFLAGS+= -pedantic -fstrict-aliasing -Wstrict-aliasing -Woverflow -Werror
+	CXXFLAGS+=-W -Wall -pedantic -fstrict-aliasing -Wstrict-aliasing -Woverflow
 endif
 ifeq ($(CXXCOMPILER), clang++)
 	COMPILER_PREFIX=clang

--- a/unittest/Makefile
+++ b/unittest/Makefile
@@ -5,7 +5,10 @@
 # {FORCE_OPENMP_PLUGIN=ON}
 # {FORCE_SCALAR_PLUGIN=ON}
 
-CXXFLAGS=-std=c++11
+CXXFLAGS=-std=c++14
+CXX=g++
+ISA=mic_avx512
+BUILD=release
 
 ifneq (,$(findstring armclang,$(CXX)))
 	CXXCOMPILER=armclang++
@@ -26,7 +29,8 @@ endif
 #some predefined rules
 ifeq ($(CXXCOMPILER), g++)
 	COMPILER_PREFIX=gcc
-	CXXFLAGS+=-W -Wall -pedantic -fstrict-aliasing -Wstrict-aliasing -Woverflow -Werror
+#-W -Wall
+	CXXFLAGS+= -pedantic -fstrict-aliasing -Wstrict-aliasing -Woverflow -Werror
 endif
 ifeq ($(CXXCOMPILER), clang++)
 	COMPILER_PREFIX=clang

--- a/unittest/UMEUnitTestCommon.h
+++ b/unittest/UMEUnitTestCommon.h
@@ -8650,9 +8650,8 @@ void genericRSHVTest_random()
 
         for (int i = 0; i < VEC_LEN; i++) {
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
-            uint64_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen);
-            inputA[i] = inputA_range == 0 ? inputA[i] : inputA[i] % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 
@@ -8674,8 +8673,8 @@ void genericRSHVTest_random()
 
         for (int i = 0; i < VEC_LEN; i++) {
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
-            SCALAR_UINT_TYPE inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 
@@ -8696,8 +8695,8 @@ void genericRSHVTest_random()
 
         for (int i = 0; i < VEC_LEN; i++) {
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
-            SCALAR_UINT_TYPE inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 
@@ -8743,8 +8742,8 @@ void genericMRSHVTest_random()
         for (int i = 0; i < VEC_LEN; i++) {
             inputMask[i] = randomValue<bool>(gen);
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB[i];
             else output[i] = inputA[i];
         }
@@ -8769,8 +8768,8 @@ void genericMRSHVTest_random()
         for (int i = 0; i < VEC_LEN; i++) {
             inputMask[i] = randomValue<bool>(gen);
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB[i];
             else output[i] = inputA[i];
         }
@@ -8816,8 +8815,8 @@ void genericRSHSTest_random()
 
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB;
         }
 
@@ -8837,8 +8836,8 @@ void genericRSHSTest_random()
 
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB;
         }
 
@@ -8858,8 +8857,8 @@ void genericRSHSTest_random()
 
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB;
         }
 
@@ -8904,8 +8903,8 @@ void genericMRSHSTest_random()
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
             inputMask[i] = randomValue<bool>(gen);
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB;
             else output[i] = inputA[i];
         }
@@ -8929,8 +8928,8 @@ void genericMRSHSTest_random()
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
             inputMask[i] = randomValue<bool>(gen);
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB;
             else output[i] = inputA[i];
         }
@@ -8975,8 +8974,8 @@ void genericRSHVATest_random()
 
         for (int i = 0; i < VEC_LEN; i++) {
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 
@@ -8995,8 +8994,8 @@ void genericRSHVATest_random()
 
         for (int i = 0; i < VEC_LEN; i++) {
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 
@@ -9040,8 +9039,8 @@ void genericMRSHVATest_random()
         for (int i = 0; i < VEC_LEN; i++) {
             inputMask[i] = randomValue<bool>(gen);
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB[i];
             else output[i] = inputA[i];
         }
@@ -9085,8 +9084,8 @@ void genericRSHSATest_random()
 
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB;
         }
 
@@ -9104,8 +9103,8 @@ void genericRSHSATest_random()
 
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB;
         }
 
@@ -9148,8 +9147,8 @@ void genericMRSHSATest_random()
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
             inputMask[i] = randomValue<bool>(gen);
-            uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = uint64_t(1) << uint64_t(MAX_BIT_COUNT);
+            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB;
             else output[i] = inputA[i];
         }

--- a/unittest/UMEUnitTestCommon.h
+++ b/unittest/UMEUnitTestCommon.h
@@ -8652,7 +8652,7 @@ void genericRSHVTest_random()
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
             uint64_t inputA_range = 1 << MAX_BIT_COUNT;
             inputA[i] = randomValue<SCALAR_TYPE>(gen);
-	    inputA[i] = inputA_range == 0 ? inputA[i] : inputA[i] % inputA_range;
+            inputA[i] = inputA_range == 0 ? inputA[i] : inputA[i] % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 

--- a/unittest/UMEUnitTestCommon.h
+++ b/unittest/UMEUnitTestCommon.h
@@ -168,6 +168,7 @@ void genericSETCONSTRTest_random_helper(std::string const & type_name)
         std::string msg("SET-CONSTR gen initializer");
         msg.append(type_name);
         check_condition(inRange, msg.c_str());
+
     }
 }
 
@@ -8649,8 +8650,9 @@ void genericRSHVTest_random()
 
         for (int i = 0; i < VEC_LEN; i++) {
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
-            SCALAR_UINT_TYPE inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            uint64_t inputA_range = 1 << MAX_BIT_COUNT;
+            inputA[i] = randomValue<SCALAR_TYPE>(gen);
+	    inputA[i] = inputA_range == 0 ? inputA[i] : inputA[i] % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 
@@ -8660,6 +8662,7 @@ void genericRSHVTest_random()
         vec2.store(values);
         bool inRange = valuesInRange(values, output, VEC_LEN, SCALAR_TYPE(0.01f));
         vec0.store(values);
+
         bool isUnmodified = valuesInRange(values, inputA, VEC_LEN, SCALAR_TYPE(0.01f));
         CHECK_CONDITION((inRange && isUnmodified), "RSHV gen");
     }
@@ -8672,7 +8675,7 @@ void genericRSHVTest_random()
         for (int i = 0; i < VEC_LEN; i++) {
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
             SCALAR_UINT_TYPE inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 
@@ -8694,7 +8697,7 @@ void genericRSHVTest_random()
         for (int i = 0; i < VEC_LEN; i++) {
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
             SCALAR_UINT_TYPE inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 
@@ -8741,7 +8744,7 @@ void genericMRSHVTest_random()
             inputMask[i] = randomValue<bool>(gen);
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB[i];
             else output[i] = inputA[i];
         }
@@ -8767,7 +8770,7 @@ void genericMRSHVTest_random()
             inputMask[i] = randomValue<bool>(gen);
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB[i];
             else output[i] = inputA[i];
         }
@@ -8814,7 +8817,7 @@ void genericRSHSTest_random()
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB;
         }
 
@@ -8835,7 +8838,7 @@ void genericRSHSTest_random()
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB;
         }
 
@@ -8856,7 +8859,7 @@ void genericRSHSTest_random()
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB;
         }
 
@@ -8902,7 +8905,7 @@ void genericMRSHSTest_random()
         for (int i = 0; i < VEC_LEN; i++) {
             inputMask[i] = randomValue<bool>(gen);
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB;
             else output[i] = inputA[i];
         }
@@ -8927,7 +8930,7 @@ void genericMRSHSTest_random()
         for (int i = 0; i < VEC_LEN; i++) {
             inputMask[i] = randomValue<bool>(gen);
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB;
             else output[i] = inputA[i];
         }
@@ -8973,7 +8976,7 @@ void genericRSHVATest_random()
         for (int i = 0; i < VEC_LEN; i++) {
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 
@@ -8993,7 +8996,7 @@ void genericRSHVATest_random()
         for (int i = 0; i < VEC_LEN; i++) {
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB[i];
         }
 
@@ -9038,7 +9041,7 @@ void genericMRSHVATest_random()
             inputMask[i] = randomValue<bool>(gen);
             inputB[i] = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB[i];
             else output[i] = inputA[i];
         }
@@ -9083,7 +9086,7 @@ void genericRSHSATest_random()
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB;
         }
 
@@ -9102,7 +9105,7 @@ void genericRSHSATest_random()
         inputB = randomValue<SCALAR_UINT_TYPE>(gen) % MAX_BIT_COUNT;
         for (int i = 0; i < VEC_LEN; i++) {
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             output[i] = inputA[i] >> inputB;
         }
 
@@ -9146,7 +9149,7 @@ void genericMRSHSATest_random()
         for (int i = 0; i < VEC_LEN; i++) {
             inputMask[i] = randomValue<bool>(gen);
             uint32_t inputA_range = 1 << MAX_BIT_COUNT;
-            inputA[i] = randomValue<SCALAR_TYPE>(gen) % inputA_range;
+            inputA[i] = inputA_range == 0 ? randomValue<SCALAR_TYPE>(gen) : randomValue<SCALAR_TYPE>(gen) % inputA_range;
             if (inputMask[i] == true) output[i] = inputA[i] >> inputB;
             else output[i] = inputA[i];
         }


### PR DESCRIPTION
knl: gcc7.1 (have to turn off -Werror)
In file included from ../plugins/avx512/UMESimdVecIntAVX512.h:59:0,
                 from ../plugins/UMESimdPluginAVX512.h:143,
                 from ../UMESimd.h:110,
                 from UMEUnitTestCommon.h:35,
                 from UMEUnitTestSimd128b.h:34,
                 from UMEUnitTestSimd128b.cpp:31:
../plugins/avx512/int/UMESimdVecInt64_2.h: In function ‘void genericINSERTTest() [with VEC_TYPE = UME::SIMD::SIMDVec_i<long int, 2>; SCALAR_TYPE = long int; int VEC_LEN = 2; DATA_SET = DataSet_1_64i]’:
../plugins/avx512/int/UMESimdVecInt64_2.h:148:28: warning: ‘vec0.UME::SIMD::SIMDVec_i<long int, 2>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             _mm_store_si128((__m128i*) raw, mVec);
             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from ../plugins/avx512/UMESimdVecUintAVX512.h:61:0,
                 from ../plugins/UMESimdPluginAVX512.h:142,
                 from ../UMESimd.h:110,
                 from UMEUnitTestCommon.h:35,
                 from UMEUnitTestSimd128b.h:34,
                 from UMEUnitTestSimd128b.cpp:31:
../plugins/avx512/uint/UMESimdVecUint64_2.h: In function ‘void genericINSERTTest() [with VEC_TYPE = UME::SIMD::SIMDVec_u<long unsigned int, 2>; SCALAR_TYPE = long unsigned int; int VEC_LEN = 2; DATA_SET = DataSet_1_64u]’:
../plugins/avx512/uint/UMESimdVecUint64_2.h:136:28: warning: ‘vec0.UME::SIMD::SIMDVec_u<long unsigned int, 2>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             _mm_store_si128((__m128i*) raw, mVec);
             ~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
In file included from ../plugins/avx512/UMESimdVecFloatAVX512.h:60:0,
                 from ../plugins/UMESimdPluginAVX512.h:144,
                 from ../UMESimd.h:110,
                 from UMEUnitTestCommon.h:35,
                 from UMEUnitTestSimd128b.h:34,
                 from UMEUnitTestSimd128b.cpp:31:
../plugins/avx512/float/UMESimdVecFloat64_2.h: In function ‘void genericINSERTTest() [with VEC_TYPE = UME::SIMD::SIMDVec_f<double, 2>; SCALAR_TYPE = double; int VEC_LEN = 2; DATA_SET = DataSet_1_64f]’:
../plugins/avx512/float/UMESimdVecFloat64_2.h:147:25: warning: ‘vec0.UME::SIMD::SIMDVec_f<double, 2>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             _mm_store_pd(raw, mVec);
             ~~~~~~~~~~~~^~~~~~~~~~~

unittests (gcc, knl):
sin/cos/log


----------------------------

knl: icc (have to turn of -Werror)
building warnings:
UMEUnitTestCommon.h(1535) (col. 24): warning #2102: violation of ansi-alias rules
many of them


unittests (knl, icc): happened only once, couldnt repeat, is an emulation function
FAIL UME::SIMD::SIMD1_8i test Id: 322 - IMIN(function)
Total tests failed: 1/32657

unittests(gcc, knl):
sin/cos/log
