### PR TITLE
Merge sp altivec and neon

### DIFF
--- a/plugins/altivec/float/UMESimdVecFloat64_2.h
+++ b/plugins/altivec/float/UMESimdVecFloat64_2.h
@@ -444,7 +444,7 @@ namespace SIMD {
         // MSUBVA
         UME_FORCE_INLINE SIMDVec_f & suba(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
             __vector double tmp = vec_sub(mVec, b.mVec);
-            __vector uint64_2 tmpmask;
+            __vector uint64_t tmpmask;
             MASK_TO_VEC(tmpmask, mask);
             mVec= vec_sel(mVec, tmp, tmpmask);
             return *this;
@@ -464,9 +464,9 @@ namespace SIMD {
             __vector double tmp;
             SET_F64(tmp, b);
             __vector double tmp2 = vec_sub(mVec, tmp);
-            __vector uint64_2 tmpmask;
+            __vector uint64_t tmpmask;
             MASK_TO_VEC(tmpmask, mask);
-            mVec= vec_sel(mVec, tmp, tmpmask);
+            mVec= vec_sel(mVec, tmp2, tmpmask);
             return *this;
         }
         // SSUBV

--- a/plugins/altivec/float/UMESimdVecFloat64_2.h
+++ b/plugins/altivec/float/UMESimdVecFloat64_2.h
@@ -36,9 +36,9 @@
 #include "../../../UMESimdInterface.h"
 
 #define SET_F64(x, a) { alignas(16) double setf64_array[2] = {a, a}; \
-                             x = *((__vector double *)(setf64_array)); }
+                             x = vec_ld(0, a); }
 #define MASK_TO_VEC(x, mask) { alignas(16) uint64_t mask_to_vec_array[2] = { (mask.mMask[0] ? 0xFFFFFFFFFFFFFFFF : 0), (mask.mMask[1] ? 0xFFFFFFFFFFFFFFFF : 0)}; \
-                             x = *((__vector uint64_t *)(mask_to_vec_array)); }
+                             x = vec_ld(mask_to_vec_array); }
 
 namespace UME {
 namespace SIMD {
@@ -100,17 +100,18 @@ namespace SIMD {
             
             // The data needs to be re-aligned so that we don't loose bits.
             alignas(16) double raw[2] = {p[0], p[1]};
-            mVec = *((__vector double*) raw);
+            mVec = vec_ld(0, raw);
         }
         // FULL-CONSTR
         UME_FORCE_INLINE SIMDVec_f(double f0, double f1) {
             alignas(16) double raw[2] = {f0, f1};
-            mVec = *((__vector double*) raw);
+            mVec = vec_ld(0, raw);
         }
 
         // EXTRACT
         UME_FORCE_INLINE double extract(uint32_t index) const {
-            return ((double*)&mVec)[index];
+            //return ((double*)&mVec)[index];
+            return vec_extract(mVec, index);
         }
         UME_FORCE_INLINE double operator[] (uint32_t index) const {
             return extract(index);
@@ -181,7 +182,7 @@ namespace SIMD {
             
             // The data needs to be re-aligned so that we don't loose bits.
             alignas(16) double raw[2] = {p[0], p[1]};
-            mVec = *((__vector double*) raw);
+            mVec = vec_ld(0, raw);
             return *this;
         }
         // MLOAD
@@ -193,7 +194,7 @@ namespace SIMD {
             
             // The data needs to be re-aligned so that we don't loose bits.
             alignas(16) double raw[2] = {p[0], p[1]};
-            __vector double t0 = *((__vector double*) raw);
+            __vector double t0 = vec_ld(0, raw);
             __vector uint64_t t1;
             MASK_TO_VEC(t1, mask);
             mVec = vec_sel(mVec, t0, t1);
@@ -201,12 +202,12 @@ namespace SIMD {
         }
         // LOADA
         UME_FORCE_INLINE SIMDVec_f & loada(double const *p) {
-            mVec = *((__vector double*) p);
+            mVec = vec_ld(0, p);
             return *this;
         }
         // MLOADA
         UME_FORCE_INLINE SIMDVec_f & loada(SIMDVecMask<2> const & mask, double const *p) {
-            __vector double t0 = *((__vector double*) p);
+            __vector double t0 = vec_ld(0, p);
             __vector uint64_t t1;
             MASK_TO_VEC(t1, mask);
             mVec = vec_sel(mVec, t0, t1);
@@ -220,13 +221,11 @@ namespace SIMD {
             // given address. Instead, the low-order bits of the address are quietly ignored."
             
             // The data needs to be re-aligned so that we don't loose bits.
-            union {
-                alignas(16) double raw[2];
-                __vector double raw_vec;
-            }x;
-            x.raw_vec = mVec;
-            p[0] = x.raw[0];
-            p[1] = x.raw[1];
+
+            alignas(16) double raw[2];
+            raw = vec_st(mVec);
+            p[0] = raw[0];
+            p[1] = raw[1];
             return p;
         }
         // MSTORE
@@ -237,35 +236,23 @@ namespace SIMD {
             // given address. Instead, the low-order bits of the address are quietly ignored."
             
             // The data needs to be re-aligned so that we don't loose bits.
-            union {
-                alignas(16) double raw[2];
-                __vector double raw_vec;
-            }x;
-            x.raw_vec = mVec;
-            if(mask.mMask[0] != 0) p[0] = x.raw[0];
-            if(mask.mMask[1] != 0) p[1] = x.raw[1];
+            alignas(16) double raw[2];
+            raw = vec_st(mVec);
+            if(mask.mMask[0] != 0) p[0] = raw[0];
+            if(mask.mMask[1] != 0) p[1] = raw[1];
             return p;
         }
         // STOREA
         UME_FORCE_INLINE double* storea(double* p) const {
-            union {
-                alignas(16) double raw[2];
-                __vector double raw_vec;
-            }x;
-            x.raw_vec = mVec;
-            p[0] = x.raw[0];
-            p[1] = x.raw[1];
+            p = vec_st(mVec);
             return p;
         }
         // MSTOREA
         UME_FORCE_INLINE double* storea(SIMDVecMask<2> const & mask, double* p) const {
-            union {
-                alignas(16) double raw[2];
-                __vector double raw_vec;
-            }x;
-            x.raw_vec = mVec;
-            if(mask.mMask[0] != 0) p[0] = x.raw[0];
-            if(mask.mMask[1] != 0) p[1] = x.raw[1];
+            alignas(16) double raw[2];
+            raw = vec_st(mVec);
+            if(mask.mMask[0] != 0) p[0] = raw[0];
+            if(mask.mMask[1] != 0) p[1] = raw[1];
             return p;
         }
 
@@ -932,9 +919,31 @@ namespace SIMD {
         // SQRA
         // MSQRA
         // SQRT
+        UME_FORCE_INLINE SIMDVec_f sqrt() const {
+            __vector double tmp = vec_sqrt(mVec);
+            return SIMDVec_f(tmp);
+        }
         // MSQRT
+        UME_FORCE_INLINE SIMDVec_f sqrt(SIMDVecMask<2> const & mask) const {
+            __vector double tmp = vec_sqrt(mVec);
+            __vector uint64_t tmpmask;
+            MASK_TO_VEC(tmpmask, mask);
+            __vector double tmp2 = vec_sel(mVec, tmp, tmpmask);
+            return SIMDVec_f(tmp2);
+        }
         // SQRTA
+        UME_FORCE_INLINE SIMDVec_f & sqrta() {
+            mVec = vec_sqrt(mVec);
+            return *this;
+        }
         // MSQRTA
+        UME_FORCE_INLINE SIMDVec_f & sqrta(SIMDVecMask<2> const & mask) {
+            __vector double tmp = vec_sqrt(mVec);
+            __vector uint64_t tmpmask;
+            MASK_TO_VEC(tmpmask, mask);
+            mVec = vec_sel(mVec, tmp, tmpmask);
+            return *this;
+        }
         // POWV
         // MPOWV
         // POWS

--- a/plugins/altivec/float/UMESimdVecFloat64_2.h
+++ b/plugins/altivec/float/UMESimdVecFloat64_2.h
@@ -434,9 +434,41 @@ namespace SIMD {
             return SIMDVec_f(t3);
         }
         // SUBVA
+        UME_FORCE_INLINE SIMDVec_f & suba(SIMDVec_f const & b) {
+            mVec = vec_sub(mVec, b.mVec);
+            return *this;
+        }
+        UME_FORCE_INLINE SIMDVec_f & operator-= (SIMDVec_f const & b) {
+            return suba(b);
+        }
         // MSUBVA
+        UME_FORCE_INLINE SIMDVec_f & suba(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
+            __vector double tmp = vec_sub(mVec, b.mVec);
+            __vector uint64_2 tmpmask;
+            MASK_TO_VEC(tmpmask, mask);
+            mVec= vec_sel(mVec, tmp, tmpmask);
+            return *this;
+        }
         // SUBSA
+        UME_FORCE_INLINE SIMDVec_f & suba(const double b) {
+            __vector double t0;
+            SET_F64(t0, b);
+            mVec = vec_sub(mVec, t0);
+            return *this;
+        }
+        UME_FORCE_INLINE SIMDVec_f & operator-= (double b) {
+            return suba(b);
+        }
         // MSUBSA
+        UME_FORCE_INLINE SIMDVec_f & suba(SIMDVecMask<2> const & mask, const double b) {
+            __vector double tmp;
+            SET_F64(tmp, b);
+            __vector double tmp2 = vec_sub(mVec, tmp);
+            __vector uint64_2 tmpmask;
+            MASK_TO_VEC(tmpmask, mask);
+            mVec= vec_sel(mVec, tmp, tmpmask);
+            return *this;
+        }
         // SSUBV
         // MSSUBV
         // SSUBS
@@ -476,9 +508,35 @@ namespace SIMD {
             return SIMDVec_f(t3);
         }
         // SUBFROMVA
+        UME_FORCE_INLINE SIMDVec_f & subfroma(SIMDVec_f const & a) {
+            mVec = vec_sub(a.mVec, mVec);
+            return *this;
+        }
         // MSUBFROMVA
+        UME_FORCE_INLINE SIMDVec_f & subfroma(SIMDVecMask<2> const & mask, SIMDVec_f const & a) {
+            __vector double tmp = vec_sub(a.mVec, mVec);
+            __vector uint64_t tmpmask;
+            MASK_TO_VEC(tmpmask, mask);
+            mVec = vec_sel(a.mVec, tmp, tmpmask);
+            return *this;
+        }
         // SUBFROMSA
+        UME_FORCE_INLINE SIMDVec_f & subfroma(double a) {
+            __vector double t0;
+            SET_F64(t0, a);
+            mVec = vec_sub(t0, mVec);
+            return *this;
+        }
         // MSUBFROMSA
+        UME_FORCE_INLINE SIMDVec_f & subfroma(SIMDVecMask<2> const & mask, double a) {
+            __vector double t0;
+            SET_F64(t0, a);
+            __vector double t1 = vec_sub(t0, mVec);
+            __vector uint64_t t2;
+            MASK_TO_VEC(t2, mask);
+            mVec = vec_sel(t0, t1, t2);
+            return *this;
+        }
         // POSTDEC
         UME_FORCE_INLINE SIMDVec_f postdec() {
             __vector double t0;
@@ -558,9 +616,42 @@ namespace SIMD {
             return SIMDVec_f(t3);
         }
         // MULVA
+        UME_FORCE_INLINE SIMDVec_f & mula(SIMDVec_f const & b) {
+            mVec = vec_mul(mVec, b.mVec);
+            return *this;
+        }
+
+        UME_FORCE_INLINE SIMDVec_f & operator*= (SIMDVec_f const & b) {
+            return mula(b);
+        }
         // MMULVA
+        UME_FORCE_INLINE SIMDVec_f & mula(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
+            __vector double t0 = vec_mul(mVec, b.mVec);
+            __vector uint64_t t1;
+            MASK_TO_VEC(t1, mask);
+            mVec = vec_sel(mVec, t0, t1);
+            return *this;
+        }
         // MULSA
+        UME_FORCE_INLINE SIMDVec_f & mula(double b) {
+            __vector double t0;
+            SET_F64(t0, b);
+            mVec = vec_mul(mVec, t0);
+            return *this;
+        }
+        UME_FORCE_INLINE SIMDVec_f & operator*= (double b) {
+            return mula(b);
+        }
         // MMULSA
+        UME_FORCE_INLINE SIMDVec_f & mula(SIMDVecMask<2> const & mask, double b) {
+            __vector double t0;
+            SET_F64(t0, b);
+            __vector double t1 = vec_mul(mVec, t0);
+            __vector uint64_t t2;
+            MASK_TO_VEC(t2, mask);
+            mVec = vec_sel(mVec, t1, t2);
+            return *this;
+        }
         // DIVV
         UME_FORCE_INLINE SIMDVec_f div(SIMDVec_f const & b) const {
             __vector double t0 = vec_div(mVec, b.mVec);
@@ -598,9 +689,41 @@ namespace SIMD {
             return SIMDVec_f(t3);
         }
         // DIVVA
+        UME_FORCE_INLINE SIMDVec_f & diva(SIMDVec_f const & b) {
+            mVec = vec_div(mVec, b.mVec);
+            return *this;
+        }
+        UME_FORCE_INLINE SIMDVec_f & operator/= (SIMDVec_f const & b) {
+            return diva(b);
+        }
         // MDIVVA
+        UME_FORCE_INLINE SIMDVec_f & diva(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
+            __vector double t0 = vec_div(mVec, b.mVec);
+            __vector uint64_t t1;
+            MASK_TO_VEC(t1, mask);
+            mVec = vec_sel(mVec, t0, t1);
+            return *this;
+        }
         // DIVSA
+        UME_FORCE_INLINE SIMDVec_f & diva(double b) {
+            __vector double t0;
+            SET_F64(t0, b);
+            mVec = vec_div(mVec, t0);
+            return *this;
+        }
+        UME_FORCE_INLINE SIMDVec_f & operator/= (double b) {
+            return diva(b);
+        }
         // MDIVSA
+        UME_FORCE_INLINE SIMDVec_f & diva(SIMDVecMask<2> const & mask, double b) {
+            __vector double t0;
+            SET_F64(t0, b);
+            __vector double t1 = vec_div(mVec, t0);
+            __vector uint64_t t2;
+            MASK_TO_VEC(t2, mask);
+            mVec = vec_sel(mVec, t1, t2);
+            return *this;
+        }
         // RCP
         UME_FORCE_INLINE SIMDVec_f rcp() const {
             //__vector double t0 = vec_recip(SET_F64(1.0), mVec);

--- a/plugins/altivec/float/UMESimdVecFloat64_2.h
+++ b/plugins/altivec/float/UMESimdVecFloat64_2.h
@@ -35,10 +35,10 @@
 
 #include "../../../UMESimdInterface.h"
 
-#define SET_F64(x, a) { alignas(16) double setf64_array[2] = {a, a}; \
-                             x = vec_ld(0, a); }
+#define SET_F64(x, a) { alignas(16) const double setf64_array[2] = {a, a}; \
+                             x = (__vector double) vec_vsx_ld(0, setf64_array); }
 #define MASK_TO_VEC(x, mask) { alignas(16) uint64_t mask_to_vec_array[2] = { (mask.mMask[0] ? 0xFFFFFFFFFFFFFFFF : 0), (mask.mMask[1] ? 0xFFFFFFFFFFFFFFFF : 0)}; \
-                             x = vec_ld(mask_to_vec_array); }
+                             x = (__vector uint64_t) vec_vsx_ld(0, mask_to_vec_array); }
 
 namespace UME {
 namespace SIMD {
@@ -100,12 +100,12 @@ namespace SIMD {
             
             // The data needs to be re-aligned so that we don't loose bits.
             alignas(16) double raw[2] = {p[0], p[1]};
-            mVec = vec_ld(0, raw);
+            mVec = vec_vsx_ld(0, raw);
         }
         // FULL-CONSTR
         UME_FORCE_INLINE SIMDVec_f(double f0, double f1) {
             alignas(16) double raw[2] = {f0, f1};
-            mVec = vec_ld(0, raw);
+            mVec = vec_vsx_ld(0, raw);
         }
 
         // EXTRACT
@@ -182,7 +182,7 @@ namespace SIMD {
             
             // The data needs to be re-aligned so that we don't loose bits.
             alignas(16) double raw[2] = {p[0], p[1]};
-            mVec = vec_ld(0, raw);
+            mVec = vec_vsx_ld(0, raw);
             return *this;
         }
         // MLOAD
@@ -194,7 +194,7 @@ namespace SIMD {
             
             // The data needs to be re-aligned so that we don't loose bits.
             alignas(16) double raw[2] = {p[0], p[1]};
-            __vector double t0 = vec_ld(0, raw);
+            __vector double t0 = vec_vsx_ld(0, raw);
             __vector uint64_t t1;
             MASK_TO_VEC(t1, mask);
             mVec = vec_sel(mVec, t0, t1);
@@ -202,12 +202,12 @@ namespace SIMD {
         }
         // LOADA
         UME_FORCE_INLINE SIMDVec_f & loada(double const *p) {
-            mVec = vec_ld(0, p);
+            mVec = vec_vsx_ld(0, p);
             return *this;
         }
         // MLOADA
         UME_FORCE_INLINE SIMDVec_f & loada(SIMDVecMask<2> const & mask, double const *p) {
-            __vector double t0 = vec_ld(0, p);
+            __vector double t0 = vec_vsx_ld(0, p);
             __vector uint64_t t1;
             MASK_TO_VEC(t1, mask);
             mVec = vec_sel(mVec, t0, t1);
@@ -223,7 +223,7 @@ namespace SIMD {
             // The data needs to be re-aligned so that we don't loose bits.
 
             alignas(16) double raw[2];
-            raw = vec_st(mVec);
+            vec_vsx_st(mVec, 0, raw);
             p[0] = raw[0];
             p[1] = raw[1];
             return p;
@@ -237,20 +237,20 @@ namespace SIMD {
             
             // The data needs to be re-aligned so that we don't loose bits.
             alignas(16) double raw[2];
-            raw = vec_st(mVec);
+            vec_vsx_st(mVec, 0, raw);
             if(mask.mMask[0] != 0) p[0] = raw[0];
             if(mask.mMask[1] != 0) p[1] = raw[1];
             return p;
         }
         // STOREA
         UME_FORCE_INLINE double* storea(double* p) const {
-            p = vec_st(mVec);
+            vec_vsx_st(mVec, 0, p);
             return p;
         }
         // MSTOREA
         UME_FORCE_INLINE double* storea(SIMDVecMask<2> const & mask, double* p) const {
             alignas(16) double raw[2];
-            raw = vec_st(mVec);
+            vec_vsx_st(mVec, 0, raw);
             if(mask.mMask[0] != 0) p[0] = raw[0];
             if(mask.mMask[1] != 0) p[1] = raw[1];
             return p;

--- a/plugins/arm/float/UMESimdVecFloat32_2.h
+++ b/plugins/arm/float/UMESimdVecFloat32_2.h
@@ -156,8 +156,8 @@ namespace SIMD {
         }
         // MASSIGNV
         UME_FORCE_INLINE SIMDVec_f & assign(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true) mVec[0] = b.mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = b.mVec[1];
+            if (mask.mMask[0]) mVec[0] = b.mVec[0];
+            if (mask.mMask[1]) mVec[1] = b.mVec[1];
             return *this;
         }
         // ASSIGNS
@@ -171,8 +171,8 @@ namespace SIMD {
         }
         // MASSIGNS
         UME_FORCE_INLINE SIMDVec_f & assign(SIMDVecMask<2> const & mask, float b) {
-            if (mask.mMask[0] == true) mVec[0] = b;
-            if (mask.mMask[1] == true) mVec[1] = b;
+            if (mask.mMask[0]) mVec[0] = b;
+            if (mask.mMask[1]) mVec[1] = b;
             return *this;
         }
 
@@ -188,8 +188,8 @@ namespace SIMD {
         }
         // MLOAD
         UME_FORCE_INLINE SIMDVec_f & load(SIMDVecMask<2> const & mask, float const * p) {
-            if (mask.mMask[0] == true) mVec[0] = p[0];
-            if (mask.mMask[1] == true) mVec[1] = p[1];
+            if (mask.mMask[0]) mVec[0] = p[0];
+            if (mask.mMask[1]) mVec[1] = p[1];
             return *this;
         }
         // LOADA
@@ -200,8 +200,8 @@ namespace SIMD {
         }
         // MLOADA
         UME_FORCE_INLINE SIMDVec_f & loada(SIMDVecMask<2> const & mask, float const * p) {
-            if (mask.mMask[0] == true) mVec[0] = p[0];
-            if (mask.mMask[1] == true) mVec[1] = p[1];
+            if (mask.mMask[0]) mVec[0] = p[0];
+            if (mask.mMask[1]) mVec[1] = p[1];
             return *this;
         }
         // STORE
@@ -212,8 +212,8 @@ namespace SIMD {
         }
         // MSTORE
         UME_FORCE_INLINE float* store(SIMDVecMask<2> const & mask, float * p) const {
-            if (mask.mMask[0] == true) p[0] = mVec[0];
-            if (mask.mMask[1] == true) p[1] = mVec[1];
+            if (mask.mMask[0]) p[0] = mVec[0];
+            if (mask.mMask[1]) p[1] = mVec[1];
             return p;
         }
         // STOREA
@@ -224,21 +224,21 @@ namespace SIMD {
         }
         // MSTOREA
         UME_FORCE_INLINE float* storea(SIMDVecMask<2> const & mask, float * p) const {
-            if (mask.mMask[0] == true) p[0] = mVec[0];
-            if (mask.mMask[1] == true) p[1] = mVec[1];
+            if (mask.mMask[0]) p[0] = mVec[0];
+            if (mask.mMask[1]) p[1] = mVec[1];
             return p;
         }
 
         // BLENDV
         UME_FORCE_INLINE SIMDVec_f blend(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
-            float t0 = (mask.mMask[0] == true) ? b.mVec[0] : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? b.mVec[1] : mVec[1];
+            float t0 = (mask.mMask[0]) ? b.mVec[0] : mVec[0];
+            float t1 = (mask.mMask[1]) ? b.mVec[1] : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // BLENDS
         UME_FORCE_INLINE SIMDVec_f blend(SIMDVecMask<2> const & mask, float b) const {
-            float t0 = (mask.mMask[0] == true) ? b : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? b : mVec[1];
+            float t0 = (mask.mMask[0]) ? b : mVec[0];
+            float t1 = (mask.mMask[1]) ? b : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // SWIZZLE
@@ -323,8 +323,8 @@ namespace SIMD {
         }
         // MPOSTINC
         UME_FORCE_INLINE SIMDVec_f postinc(SIMDVecMask<2> const & mask) {
-            float t0 = (mask.mMask[0] == true) ? mVec[0]++ : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? mVec[1]++ : mVec[1];
+            float t0 = (mask.mMask[0]) ? mVec[0]++ : mVec[0];
+            float t1 = (mask.mMask[1]) ? mVec[1]++ : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // PREFINC
@@ -338,8 +338,8 @@ namespace SIMD {
         }
         // MPREFINC
         UME_FORCE_INLINE SIMDVec_f & prefinc(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) ++mVec[0];
-            if (mask.mMask[1] == true) ++mVec[1];
+            if (mask.mMask[0]) ++mVec[0];
+            if (mask.mMask[1]) ++mVec[1];
             return *this;
         }
         // SUBV
@@ -353,8 +353,8 @@ namespace SIMD {
         }
         // MSUBV
         UME_FORCE_INLINE SIMDVec_f sub(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
-            float t0 = (mask.mMask[0] == true) ? (mVec[0] - b.mVec[0]) : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? (mVec[1] - b.mVec[1]) : mVec[1];
+            float t0 = (mask.mMask[0]) ? (mVec[0] - b.mVec[0]) : mVec[0];
+            float t1 = (mask.mMask[1]) ? (mVec[1] - b.mVec[1]) : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // SUBS
@@ -368,8 +368,8 @@ namespace SIMD {
         }
         // MSUBS
         UME_FORCE_INLINE SIMDVec_f sub(SIMDVecMask<2> const & mask, float b) const {
-            float t0 = (mask.mMask[0] == true) ? (mVec[0] - b) : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? (mVec[1] - b) : mVec[1];
+            float t0 = (mask.mMask[0]) ? (mVec[0] - b) : mVec[0];
+            float t1 = (mask.mMask[1]) ? (mVec[1] - b) : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // SUBVA
@@ -383,8 +383,8 @@ namespace SIMD {
         }
         // MSUBVA
         UME_FORCE_INLINE SIMDVec_f & suba(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true) mVec[0] = mVec[0] - b.mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = mVec[1] - b.mVec[1];
+            if (mask.mMask[0]) mVec[0] = mVec[0] - b.mVec[0];
+            if (mask.mMask[1]) mVec[1] = mVec[1] - b.mVec[1];
             return *this;
         }
         // SUBSA
@@ -398,8 +398,8 @@ namespace SIMD {
         }
         // MSUBSA
         UME_FORCE_INLINE SIMDVec_f & suba(SIMDVecMask<2> const & mask, const float b) {
-            if (mask.mMask[0] == true) mVec[0] = mVec[0] - b;
-            if (mask.mMask[1] == true) mVec[1] = mVec[1] - b;
+            if (mask.mMask[0]) mVec[0] = mVec[0] - b;
+            if (mask.mMask[1]) mVec[1] = mVec[1] - b;
             return *this;
         }
         // SSUBV
@@ -418,8 +418,8 @@ namespace SIMD {
         }
         // MSUBFROMV
         UME_FORCE_INLINE SIMDVec_f subfrom(SIMDVecMask<2> const & mask, SIMDVec_f const & a) const {
-            float t0 = (mask.mMask[0] == true) ? (a.mVec[0] - mVec[0]) : a[0];
-            float t1 = (mask.mMask[1] == true) ? (a.mVec[1] - mVec[1]) : a[1];
+            float t0 = (mask.mMask[0]) ? (a.mVec[0] - mVec[0]) : a[0];
+            float t1 = (mask.mMask[1]) ? (a.mVec[1] - mVec[1]) : a[1];
             return SIMDVec_f(t0, t1);
         }
         // SUBFROMS
@@ -430,8 +430,8 @@ namespace SIMD {
         }
         // MSUBFROMS
         UME_FORCE_INLINE SIMDVec_f subfrom(SIMDVecMask<2> const & mask, float a) const {
-            float t0 = (mask.mMask[0] == true) ? (a - mVec[0]) : a;
-            float t1 = (mask.mMask[1] == true) ? (a - mVec[1]) : a;
+            float t0 = (mask.mMask[0]) ? (a - mVec[0]) : a;
+            float t1 = (mask.mMask[1]) ? (a - mVec[1]) : a;
             return SIMDVec_f(t0, t1);
         }
         // SUBFROMVA
@@ -442,8 +442,8 @@ namespace SIMD {
         }
         // MSUBFROMVA
         UME_FORCE_INLINE SIMDVec_f & subfroma(SIMDVecMask<2> const & mask, SIMDVec_f const & a) {
-            mVec[0] = (mask.mMask[0] == true) ? (a.mVec[0] - mVec[0]) : a.mVec[0];
-            mVec[1] = (mask.mMask[1] == true) ? (a.mVec[1] - mVec[1]) : a.mVec[1];
+            mVec[0] = (mask.mMask[0]) ? (a.mVec[0] - mVec[0]) : a.mVec[0];
+            mVec[1] = (mask.mMask[1]) ? (a.mVec[1] - mVec[1]) : a.mVec[1];
             return *this;
         }
         // SUBFROMSA
@@ -454,8 +454,8 @@ namespace SIMD {
         }
         // MSUBFROMSA
         UME_FORCE_INLINE SIMDVec_f & subfroma(SIMDVecMask<2> const & mask, float a) {
-            mVec[0] = (mask.mMask[0] == true) ? (a - mVec[0]) : a;
-            mVec[1] = (mask.mMask[1] == true) ? (a - mVec[1]) : a;
+            mVec[0] = (mask.mMask[0]) ? (a - mVec[0]) : a;
+            mVec[1] = (mask.mMask[1]) ? (a - mVec[1]) : a;
             return *this;
         }
         // POSTDEC
@@ -469,8 +469,8 @@ namespace SIMD {
         }
         // MPOSTDEC
         UME_FORCE_INLINE SIMDVec_f postdec(SIMDVecMask<2> const & mask) {
-            float t0 = (mask.mMask[0] == true) ? mVec[0]-- : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? mVec[1]-- : mVec[1];
+            float t0 = (mask.mMask[0]) ? mVec[0]-- : mVec[0];
+            float t1 = (mask.mMask[1]) ? mVec[1]-- : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // PREFDEC
@@ -484,8 +484,8 @@ namespace SIMD {
         }
         // MPREFDEC
         UME_FORCE_INLINE SIMDVec_f & prefdec(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) --mVec[0];
-            if (mask.mMask[1] == true) --mVec[1];
+            if (mask.mMask[0]) --mVec[0];
+            if (mask.mMask[1]) --mVec[1];
             return *this;
         }
         // MULV
@@ -529,8 +529,8 @@ namespace SIMD {
         }
         // MMULVA
         UME_FORCE_INLINE SIMDVec_f & mula(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true) mVec[0] *= b.mVec[0];
-            if (mask.mMask[1] == true) mVec[1] *= b.mVec[1];
+            if (mask.mMask[0]) mVec[0] *= b.mVec[0];
+            if (mask.mMask[1]) mVec[1] *= b.mVec[1];
             return *this;
         }
         // MULSA
@@ -544,8 +544,8 @@ namespace SIMD {
         }
         // MMULSA
         UME_FORCE_INLINE SIMDVec_f & mula(SIMDVecMask<2> const & mask, float b) {
-            if (mask.mMask[0] == true) mVec[0] *= b;
-            if (mask.mMask[1] == true) mVec[1] *= b;
+            if (mask.mMask[0]) mVec[0] *= b;
+            if (mask.mMask[1]) mVec[1] *= b;
             return *this;
         }
         // DIVV
@@ -589,8 +589,8 @@ namespace SIMD {
         }
         // MDIVVA
         UME_FORCE_INLINE SIMDVec_f & diva(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true) mVec[0] /= b.mVec[0];
-            if (mask.mMask[1] == true) mVec[1] /= b.mVec[1];
+            if (mask.mMask[0]) mVec[0] /= b.mVec[0];
+            if (mask.mMask[1]) mVec[1] /= b.mVec[1];
             return *this;
         }
         // DIVSA
@@ -604,8 +604,8 @@ namespace SIMD {
         }
         // MDIVSA
         UME_FORCE_INLINE SIMDVec_f & diva(SIMDVecMask<2> const & mask, float b) {
-            if (mask.mMask[0] == true) mVec[0] /= b;
-            if (mask.mMask[1] == true) mVec[1] /= b;
+            if (mask.mMask[0]) mVec[0] /= b;
+            if (mask.mMask[1]) mVec[1] /= b;
             return *this;
         }
         // RCP
@@ -640,8 +640,8 @@ namespace SIMD {
         }
         // MRCPA
         UME_FORCE_INLINE SIMDVec_f & rcpa(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) mVec[0] = 1.0f / mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = 1.0f / mVec[1];
+            if (mask.mMask[0]) mVec[0] = 1.0f / mVec[0];
+            if (mask.mMask[1]) mVec[1] = 1.0f / mVec[1];
             return *this;
         }
         // RCPSA
@@ -652,8 +652,8 @@ namespace SIMD {
         }
         // MRCPSA
         UME_FORCE_INLINE SIMDVec_f & rcpa(SIMDVecMask<2> const & mask, float b) {
-            if (mask.mMask[0] == true) mVec[0] = b / mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = b / mVec[1];
+            if (mask.mMask[0]) mVec[0] = b / mVec[0];
+            if (mask.mMask[1]) mVec[1] = b / mVec[1];
             return *this;
         }
 
@@ -731,40 +731,37 @@ namespace SIMD {
         }
         // CMPGEV
         UME_FORCE_INLINE SIMDVecMask<2> cmpge(SIMDVec_f const & b) const {
-            SIMDVecMask<2> mask;
-            mask.mMask[0] = mVec[0] >= b.mVec[0];
-            mask.mMask[1] = mVec[1] >= b.mVec[1];
-            return mask;
+
+            bool m0 = mVec[0] >= b.mVec[0];
+            bool m1 = mVec[1] >= b.mVec[1];
+            return SIMDVecMask<2>(m0, m1);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator>= (SIMDVec_f const & b) const {
             return cmpge(b);
         }
         // CMPGES
         UME_FORCE_INLINE SIMDVecMask<2> cmpge(float b) const {
-            SIMDVecMask<2> mask;
-            mask.mMask[0] = mVec[0] >= b;
-            mask.mMask[1] = mVec[1] >= b;
-            return mask;
+            bool m0 = mVec[0] >= b;
+            bool m1 = mVec[1] >= b;
+            return SIMDVecMask<2>(m0, m1);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator>= (float b) const {
             return cmpge(b);
         }
         // CMPLEV
         UME_FORCE_INLINE SIMDVecMask<2> cmple(SIMDVec_f const & b) const {
-            SIMDVecMask<2> mask;
-            mask.mMask[0] = mVec[0] <= b.mVec[0];
-            mask.mMask[1] = mVec[1] <= b.mVec[1];
-            return mask;
+            bool m0 = mVec[0] <= b.mVec[0];
+            bool m1 = mVec[1] <= b.mVec[1];
+            return SIMDVecMask<2>(m0, m1);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator<= (SIMDVec_f const & b) const {
             return cmple(b);
         }
         // CMPLES
         UME_FORCE_INLINE SIMDVecMask<2> cmple(float b) const {
-            SIMDVecMask<2> mask;
-            mask.mMask[0] = mVec[0] <= b;
-            mask.mMask[1] = mVec[1] <= b;
-            return mask;
+            bool m0 = mVec[0] <= b;
+            bool m1 = mVec[1] <= b;
+            return SIMDVecMask<2>(m0, m1);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator<= (float b) const {
             return cmple(b);
@@ -834,8 +831,8 @@ namespace SIMD {
         }
         // MFMULADDV
         UME_FORCE_INLINE SIMDVec_f fmuladd(SIMDVecMask<2> const & mask, SIMDVec_f const & b, SIMDVec_f const & c) const {
-            float t0 = (mask.mMask[0] == true) ? (mVec[0] * b.mVec[0] + c.mVec[0]) : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? (mVec[1] * b.mVec[1] + c.mVec[1]) : mVec[1];
+            float t0 = (mask.mMask[0]) ? (mVec[0] * b.mVec[0] + c.mVec[0]) : mVec[0];
+            float t1 = (mask.mMask[1]) ? (mVec[1] * b.mVec[1] + c.mVec[1]) : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // FMULSUBV
@@ -846,8 +843,8 @@ namespace SIMD {
         }
         // MFMULSUBV
         UME_FORCE_INLINE SIMDVec_f fmulsub(SIMDVecMask<2> const & mask, SIMDVec_f const & b, SIMDVec_f const & c) const {
-            float t0 = (mask.mMask[0] == true) ? (mVec[0] * b.mVec[0] - c.mVec[0]) : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? (mVec[1] * b.mVec[1] - c.mVec[1]) : mVec[1];
+            float t0 = (mask.mMask[0]) ? (mVec[0] * b.mVec[0] - c.mVec[0]) : mVec[0];
+            float t1 = (mask.mMask[1]) ? (mVec[1] * b.mVec[1] - c.mVec[1]) : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // FADDMULV
@@ -858,8 +855,8 @@ namespace SIMD {
         }
         // MFADDMULV
         UME_FORCE_INLINE SIMDVec_f faddmul(SIMDVecMask<2> const & mask, SIMDVec_f const & b, SIMDVec_f const & c) const {
-            float t0 = (mask.mMask[0] == true) ? ((mVec[0] + b.mVec[0]) * c.mVec[0]) : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? ((mVec[1] + b.mVec[1]) * c.mVec[1]) : mVec[1];
+            float t0 = (mask.mMask[0]) ? ((mVec[0] + b.mVec[0]) * c.mVec[0]) : mVec[0];
+            float t1 = (mask.mMask[1]) ? ((mVec[1] + b.mVec[1]) * c.mVec[1]) : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // FSUBMULV
@@ -870,8 +867,8 @@ namespace SIMD {
         }
         // MFSUBMULV
         UME_FORCE_INLINE SIMDVec_f fsubmul(SIMDVecMask<2> const & mask, SIMDVec_f const & b, SIMDVec_f const & c) const {
-            float t0 = (mask.mMask[0] == true) ? ((mVec[0] - b.mVec[0]) * c.mVec[0]) : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? ((mVec[1] - b.mVec[1]) * c.mVec[1]) : mVec[1];
+            float t0 = (mask.mMask[0]) ? ((mVec[0] - b.mVec[0]) * c.mVec[0]) : mVec[0];
+            float t1 = (mask.mMask[1]) ? ((mVec[1] - b.mVec[1]) * c.mVec[1]) : mVec[1];
             return SIMDVec_f(t0, t1);
         }
 
@@ -884,10 +881,10 @@ namespace SIMD {
         // MMAXV
         UME_FORCE_INLINE SIMDVec_f max(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
             float t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = (mVec[0] > b.mVec[0]) ? mVec[0] : b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = (mVec[1] > b.mVec[1]) ? mVec[1] : b.mVec[1];
             }
             return SIMDVec_f(t0, t1);
@@ -901,10 +898,10 @@ namespace SIMD {
         // MMAXS
         UME_FORCE_INLINE SIMDVec_f max(SIMDVecMask<2> const & mask, float b) const {
             float t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = (mVec[0] > b) ? mVec[0] : b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = (mVec[1] > b) ? mVec[1] : b;
             }
             return SIMDVec_f(t0, t1);
@@ -917,10 +914,10 @@ namespace SIMD {
         }
         // MMAXVA
         UME_FORCE_INLINE SIMDVec_f & maxa(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true && mVec[0] < b.mVec[0]) {
+            if (mask.mMask[0] && mVec[0] < b.mVec[0]) {
                 mVec[0] = b.mVec[0];
             }
-            if (mask.mMask[1] == true && mVec[1] < b.mVec[1]) {
+            if (mask.mMask[1] && mVec[1] < b.mVec[1]) {
                 mVec[1] = b.mVec[1];
             }
             return *this;
@@ -933,10 +930,10 @@ namespace SIMD {
         }
         // MMAXSA
         UME_FORCE_INLINE SIMDVec_f & maxa(SIMDVecMask<2> const & mask, float b) {
-            if (mask.mMask[0] == true && mVec[0] < b) {
+            if (mask.mMask[0] && mVec[0] < b) {
                 mVec[0] = b;
             }
-            if (mask.mMask[1] == true && mVec[1] < b) {
+            if (mask.mMask[1] && mVec[1] < b) {
                 mVec[1] = b;
             }
             return *this;
@@ -950,10 +947,10 @@ namespace SIMD {
         // MMINV
         UME_FORCE_INLINE SIMDVec_f min(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
             float t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = (mVec[0] < b.mVec[0]) ? mVec[0] : b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = (mVec[1] < b.mVec[1]) ? mVec[1] : b.mVec[1];
             }
             return SIMDVec_f(t0, t1);
@@ -967,10 +964,10 @@ namespace SIMD {
         // MMINS
         UME_FORCE_INLINE SIMDVec_f min(SIMDVecMask<2> const & mask, float b) const {
             float t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = mVec[0] < b ? mVec[0] : b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = mVec[1] < b ? mVec[1] : b;
             }
             return SIMDVec_f(t0, t1);
@@ -983,10 +980,10 @@ namespace SIMD {
         }
         // MMINVA
         UME_FORCE_INLINE SIMDVec_f & mina(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true && mVec[0] > b.mVec[0]) {
+            if (mask.mMask[0] && mVec[0] > b.mVec[0]) {
                 mVec[0] = b.mVec[0];
             }
-            if (mask.mMask[1] == true && mVec[1] > b.mVec[1]) {
+            if (mask.mMask[1] && mVec[1] > b.mVec[1]) {
                 mVec[1] = b.mVec[1];
             }
             return *this;
@@ -999,10 +996,10 @@ namespace SIMD {
         }
         // MMINSA
         UME_FORCE_INLINE SIMDVec_f & mina(SIMDVecMask<2> const & mask, float b) {
-            if (mask.mMask[0] == true && mVec[0] > b) {
+            if (mask.mMask[0] && mVec[0] > b) {
                 mVec[0] = b;
             }
-            if (mask.mMask[1] == true && mVec[1] > b) {
+            if (mask.mMask[1] && mVec[1] > b) {
                 mVec[1] = b;
             }
             return *this;
@@ -1025,11 +1022,11 @@ namespace SIMD {
         UME_FORCE_INLINE int32_t imax(SIMDVecMask<2> const & mask) const {
             int32_t i0 = 0xFFFFFFFF;
             float t0 = std::numeric_limits<float>::min();
-            if(mask.mMask[0] == true) {
+            if(mask.mMask[0]) {
                 i0 = 0;
                 t0 = mVec[0];
             }
-            if(mask.mMask[1] == true && mVec[1] > t0) {
+            if(mask.mMask[1] && mVec[1] > t0) {
                 i0 = 1;
             }
             return i0;
@@ -1052,11 +1049,11 @@ namespace SIMD {
         UME_FORCE_INLINE int32_t imin(SIMDVecMask<2> const & mask) const {
             int32_t i0 = 0xFFFFFFFF;
             float t0 = std::numeric_limits<float>::max();
-            if(mask.mMask[0] == true) {
+            if(mask.mMask[0]) {
                 i0 = 0;
                 t0 = mVec[0];
             }
-            if(mask.mMask[1] == true && mVec[1] < t0) {
+            if(mask.mMask[1] && mVec[1] < t0) {
                 i0 = 1;
             }
             return i0;
@@ -1070,8 +1067,8 @@ namespace SIMD {
         }
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, uint32_t const * indices) {
-            if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
-            if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
+            if (mask.mMask[0]) mVec[0] = baseAddr[indices[0]];
+            if (mask.mMask[1]) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
@@ -1082,8 +1079,8 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, float const * baseAddr, VEC_UINT_TYPE const & indices) {
-            if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
-            if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
+            if (mask.mMask[0]) mVec[0] = baseAddr[indices.mVec[0]];
+            if (mask.mMask[1]) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // SCATTERS
@@ -1094,8 +1091,8 @@ namespace SIMD {
         }
         // MSCATTERS
         UME_FORCE_INLINE float * scatter(SIMDVecMask<2> const & mask, float * baseAddr, uint32_t * indices) const {
-            if (mask.mMask[0] == true) baseAddr[indices[0]] = mVec[0];
-            if (mask.mMask[1] == true) baseAddr[indices[1]] = mVec[1];
+            if (mask.mMask[0]) baseAddr[indices[0]] = mVec[0];
+            if (mask.mMask[1]) baseAddr[indices[1]] = mVec[1];
             return baseAddr;
         }
         // SCATTERV
@@ -1106,8 +1103,8 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE float * scatter(SIMDVecMask<2> const & mask, float * baseAddr, VEC_UINT_TYPE const & indices) const {
-            if (mask.mMask[0] == true) baseAddr[indices.mVec[0]] = mVec[0];
-            if (mask.mMask[1] == true) baseAddr[indices.mVec[1]] = mVec[1];
+            if (mask.mMask[0]) baseAddr[indices.mVec[0]] = mVec[0];
+            if (mask.mMask[1]) baseAddr[indices.mVec[1]] = mVec[1];
             return baseAddr;
         }
         // NEG
@@ -1119,8 +1116,8 @@ namespace SIMD {
         }
         // MNEG
         UME_FORCE_INLINE SIMDVec_f neg(SIMDVecMask<2> const & mask) const {
-            float t0 = (mask.mMask[0] == true) ? -mVec[0] : mVec[0];
-            float t1 = (mask.mMask[1] == true) ? -mVec[1] : mVec[1];
+            float t0 = (mask.mMask[0]) ? -mVec[0] : mVec[0];
+            float t1 = (mask.mMask[1]) ? -mVec[1] : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // NEGA
@@ -1131,8 +1128,8 @@ namespace SIMD {
         }
         // MNEGA
         UME_FORCE_INLINE SIMDVec_f & nega(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) mVec[0] = -mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = -mVec[1];
+            if (mask.mMask[0]) mVec[0] = -mVec[0];
+            if (mask.mMask[1]) mVec[1] = -mVec[1];
             return *this;
         }
         // ABS
@@ -1143,8 +1140,8 @@ namespace SIMD {
         }
         // MABS
         UME_FORCE_INLINE SIMDVec_f abs(SIMDVecMask<2> const & mask) const {
-            float t0 = ((mask.mMask[0] == true) && (mVec[0] < 0.0f)) ? -mVec[0] : mVec[0];
-            float t1 = ((mask.mMask[1] == true) && (mVec[1] < 0.0f)) ? -mVec[1] : mVec[1];
+            float t0 = ((mask.mMask[0]) && (mVec[0] < 0.0f)) ? -mVec[0] : mVec[0];
+            float t1 = ((mask.mMask[1]) && (mVec[1] < 0.0f)) ? -mVec[1] : mVec[1];
             return SIMDVec_f(t0, t1);
         }
         // ABSA
@@ -1155,8 +1152,8 @@ namespace SIMD {
         }
         // MABSA
         UME_FORCE_INLINE SIMDVec_f & absa(SIMDVecMask<2> const & mask) {
-            if ((mask.mMask[0] == true) && (mVec[0] < 0.0f)) mVec[0] = -mVec[0];
-            if ((mask.mMask[1] == true) && (mVec[1] < 0.0f)) mVec[1] = -mVec[1];
+            if ((mask.mMask[0]) && (mVec[0] < 0.0f)) mVec[0] = -mVec[0];
+            if ((mask.mMask[1]) && (mVec[1] < 0.0f)) mVec[1] = -mVec[1];
             return *this;
         }
 

--- a/plugins/arm/float/UMESimdVecFloat32_4.h
+++ b/plugins/arm/float/UMESimdVecFloat32_4.h
@@ -215,7 +215,7 @@ namespace SIMD {
         // MSTORE
         UME_FORCE_INLINE float* store(SIMDVecMask<4> const & mask, float* p) const {
             float32x4_t t0 = vld1q_f32(p);
-            float32x4_t tmp1 = vbslq_f32(mask.mMask, mVec, t0);
+            float32x4_t t1 = vbslq_f32(mask.mMask, mVec, t0);
             vst1q_f32(p, t1);
             return p;
         }
@@ -620,7 +620,7 @@ namespace SIMD {
         // MSUBFROMV
         UME_FORCE_INLINE SIMDVec_f subfrom(SIMDVecMask<4> const & mask, SIMDVec_f const & b) const {
             float32x4_t tmp = vsubq_f32(b.mVec, mVec);
-            float32x4_t tmp2 = vbslq_f32(mask.mMask, b.mVec, tmp);
+            float32x4_t tmp2 = vbslq_f32(mask.mMask, tmp, b.mVec);
             return SIMDVec_f(tmp2);
         }
         // SUBFROMS
@@ -633,7 +633,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_f subfrom(SIMDVecMask<4> const & mask, float b) const {
             float32x4_t tmp = vdupq_n_f32(b);
             float32x4_t tmp2 = vsubq_f32(tmp, mVec);
-            float32x4_t tmp3 = vbslq_f32(mask.mMask, tmp, tmp2);
+            float32x4_t tmp3 = vbslq_f32(mask.mMask, tmp2, tmp);
             return SIMDVec_f(tmp3);
         }
         // SUBFROMVA
@@ -721,7 +721,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_f mul(SIMDVecMask<4> const & mask, float b) const {
             float32x4_t t0 = vdupq_n_f32(b);
             float32x4_t t1 = vmulq_f32(mVec, t0);
-            float32x4_t t2 = vbslq_f32(mask.mMask, t0, mVec);
+            float32x4_t t2 = vbslq_f32(mask.mMask, t1, mVec);
             return SIMDVec_f(t2);
         }
         // MULVA
@@ -816,14 +816,18 @@ namespace SIMD {
         }
         // RCP
         UME_FORCE_INLINE SIMDVec_f rcp() const {
-            float32x4_t tmp = vrecpeq_f32(mVec);
-            return SIMDVec_f(tmp);
+            //float32x4_t tmp = vrecpeq_f32(mVec); too inacurate
+            float32x4_t tmp = vdupq_n_f32(1.0f);
+	    float32x4_t tmp2 = vdivq_f32(tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // MRCP
         UME_FORCE_INLINE SIMDVec_f rcp(SIMDVecMask<4> const & mask) const {
-            float32x4_t tmp = vrecpeq_f32(mVec);
-            float32x4_t tmp2 = vbslq_f32(mask.mMask, tmp, mVec);
-            return SIMDVec_f(tmp2);
+            //float32x4_t tmp = vrecpeq_f32(mVec);
+            float32x4_t tmp = vdupq_n_f32(1.0f);
+	    float32x4_t tmp2 = vdivq_f32(tmp, mVec);
+            float32x4_t tmp3 = vbslq_f32(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
         // RCPS
         UME_FORCE_INLINE SIMDVec_f rcp(float b) const {
@@ -840,13 +844,17 @@ namespace SIMD {
         }
         // RCPA
         UME_FORCE_INLINE SIMDVec_f & rcpa() {
-            mVec = vrecpeq_f32(mVec);
+            //mVec = vrecpeq_f32(mVec);
+            float32x4_t tmp = vdupq_n_f32(1.0f);
+	    mVec = vdivq_f32(tmp, mVec);
             return *this;
         }
         // MRCPA
         UME_FORCE_INLINE SIMDVec_f & rcpa(SIMDVecMask<4> const & mask) {
-            float32x4_t tmp = vrecpeq_f32(mVec);
-            mVec = vbslq_f32(mask.mMask, tmp, mVec);
+            //float32x4_t tmp = vrecpeq_f32(mVec);
+            float32x4_t tmp = vdupq_n_f32(1.0f);
+	    float32x4_t tmp2 = vdivq_f32(tmp, mVec);
+            mVec = vbslq_f32(mask.mMask, tmp2, mVec);
             return *this;
         }
         // RCPSA
@@ -883,7 +891,7 @@ namespace SIMD {
         // CMPNEV
         UME_FORCE_INLINE SIMDVecMask<4> cmpne(SIMDVec_f const & b) const {
             uint32x4_t tmp = vmvnq_u32(vceqq_f32(mVec, b.mVec));
-            return SIMDVecMask<2>(tmp);
+            return SIMDVecMask<4>(tmp);
         }
         UME_FORCE_INLINE SIMDVecMask<4> operator!= (SIMDVec_f const & b) const {
             return cmpne(b);
@@ -1352,7 +1360,7 @@ namespace SIMD {
         // MNEG
         UME_FORCE_INLINE SIMDVec_f neg(SIMDVecMask<4> const & mask) const {
             float32x4_t t0 = vnegq_f32(mVec);
-            float32x4_t t1 = vbslq_f32(mask.mMask, tmp, mVec);
+            float32x4_t t1 = vbslq_f32(mask.mMask, t0, mVec);
             return SIMDVec_f(t1);
         }
         // NEGA
@@ -1412,7 +1420,7 @@ namespace SIMD {
             return *this;
         }
         // MSQRTA
-        UME_FORCE_INLINE SIMDVec_f & sqrta(SIMDVecMask<2> const & mask) {
+        UME_FORCE_INLINE SIMDVec_f & sqrta(SIMDVecMask<4> const & mask) {
             float32x4_t tmp = vsqrtq_f32(mVec);
             mVec = vbslq_f32(mask.mMask, tmp, mVec);
             return *this;

--- a/plugins/arm/float/UMESimdVecFloat64_2.h
+++ b/plugins/arm/float/UMESimdVecFloat64_2.h
@@ -35,6 +35,8 @@
 
 #include "../../../UMESimdInterface.h"
 
+#define GET_CONST_INT(x) x == 0 ? 0 : x == 1
+
 namespace UME {
 namespace SIMD {
 
@@ -55,11 +57,15 @@ namespace SIMD {
             SIMDVec_f<double, 1>>
     {
     private:
-        double mVec[2];
+        float64x2_t mVec;
 
         typedef SIMDVec_u<uint64_t, 2>    VEC_UINT_TYPE;
         typedef SIMDVec_i<int64_t, 2>     VEC_INT_TYPE;
         typedef SIMDVec_f<double, 1>       HALF_LEN_VEC_TYPE;
+
+        UME_FORCE_INLINE explicit SIMDVec_f(float64x2_t const & x) {
+            this->mVec = x;
+        }
     public:
         constexpr static uint32_t length() { return 2; }
         constexpr static uint32_t alignment() { return 16; }
@@ -68,8 +74,7 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_f() {}
         // SET-CONSTR
         UME_FORCE_INLINE SIMDVec_f(double f) {
-            mVec[0] = f;
-            mVec[1] = f;
+            mVec = vdupq_n_f64(f);
         }
         // This constructor is used to force types other than SCALAR_TYPES
         // to be promoted to SCALAR_TYPE instead of SCALAR_TYPE*. This prevents
@@ -83,18 +88,21 @@ namespace SIMD {
         : SIMDVec_f(static_cast<double>(i)) {}
         // LOAD-CONSTR
         UME_FORCE_INLINE explicit SIMDVec_f(double const *p) {
-            mVec[0] = p[0];
-            mVec[1] = p[1];
+            mVec = vld1q_f64(p);
         }
         // FULL-CONSTR
         UME_FORCE_INLINE SIMDVec_f(double x_lo, double x_hi) {
-            mVec[0] = x_lo;
-            mVec[1] = x_hi;
+            alignas(16) double tmp[2] = {x_lo, x_hi};
+
+            mVec = vld1q_f64(tmp);
         }
 
         // EXTRACT
         UME_FORCE_INLINE double extract(uint32_t index) const {
-            return mVec[index & 1];
+            if ((index & 1) == 0) {
+                return vgetq_lane_f64(mVec, 0);
+            }
+            return vgetq_lane_f64(mVec, 1);
         }
         UME_FORCE_INLINE double operator[] (uint32_t index) const {
             return extract(index);
@@ -102,7 +110,11 @@ namespace SIMD {
 
         // INSERT
         UME_FORCE_INLINE SIMDVec_f & insert(uint32_t index, double value) {
-            mVec[index & 1] = value;
+            if ((index & 1) == 0) {
+                mVec = vsetq_lane_f64(value, mVec, 0);
+                return *this;
+            }
+            mVec = vsetq_lane_f64(value, mVec, 1);
             return *this;
         }
         UME_FORCE_INLINE IntermediateIndex<SIMDVec_f, double> operator[] (uint32_t index) {
@@ -126,8 +138,7 @@ namespace SIMD {
 
         // ASSIGNV
         UME_FORCE_INLINE SIMDVec_f & assign(SIMDVec_f const & b) {
-            mVec[0] = b.mVec[0];
-            mVec[1] = b.mVec[1];
+            mVec = b.mVec;
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator= (SIMDVec_f const & b) {
@@ -135,14 +146,12 @@ namespace SIMD {
         }
         // MASSIGNV
         UME_FORCE_INLINE SIMDVec_f & assign(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true) mVec[0] = b.mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = b.mVec[1];
+            mVec = vbslq_f64(mask.mMask, b.mVec, mVec);
             return *this;
         }
         // ASSIGNS
         UME_FORCE_INLINE SIMDVec_f & assign(double b) {
-            mVec[0] = b;
-            mVec[1] = b;
+            mVec = vdupq_n_f64(b);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator= (double b) {
@@ -150,8 +159,8 @@ namespace SIMD {
         }
         // MASSIGNS
         UME_FORCE_INLINE SIMDVec_f & assign(SIMDVecMask<2> const & mask, double b) {
-            if (mask.mMask[0] == true) mVec[0] = b;
-            if (mask.mMask[1] == true) mVec[1] = b;
+            float64x2_t tmp =  vdupq_n_f64(b);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
 
@@ -161,102 +170,98 @@ namespace SIMD {
 
         // LOAD
         UME_FORCE_INLINE SIMDVec_f & load(double const * p) {
-            mVec[0] = p[0];
-            mVec[1] = p[1];
+            mVec = vld1q_f64(p);
             return *this;
         }
         // MLOAD
         UME_FORCE_INLINE SIMDVec_f & load(SIMDVecMask<2> const & mask, double const * p) {
-            if (mask.mMask[0] == true) mVec[0] = p[0];
-            if (mask.mMask[1] == true) mVec[1] = p[1];
+            float64x2_t tmp = vld1q_f64(p);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
         // LOADA
         UME_FORCE_INLINE SIMDVec_f & loada(double const * p) {
-            mVec[0] = p[0];
-            mVec[1] = p[1];
+            mVec = vld1q_f64(p);
             return *this;
         }
         // MLOADA
         UME_FORCE_INLINE SIMDVec_f & loada(SIMDVecMask<2> const & mask, double const * p) {
-            if (mask.mMask[0] == true) mVec[0] = p[0];
-            if (mask.mMask[1] == true) mVec[1] = p[1];
+            float64x2_t tmp = vld1q_f64(p);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
         // STORE
         UME_FORCE_INLINE double* store(double * p) const {
-            p[0] = mVec[0];
-            p[1] = mVec[1];
+            vst1q_f64(p, mVec);
             return p;
         }
         // MSTORE
         UME_FORCE_INLINE double* store(SIMDVecMask<2> const & mask, double * p) const {
-            if (mask.mMask[0] == true) p[0] = mVec[0];
-            if (mask.mMask[1] == true) p[1] = mVec[1];
+            float64x2_t tmp = vld1q_f64(p);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, mVec, tmp);
+            vst1q_f64(p, tmp2);
             return p;
         }
         // STOREA
         UME_FORCE_INLINE double* storea(double * p) const {
-            p[0] = mVec[0];
-            p[1] = mVec[1];
+            vst1q_f64(p, mVec);
             return p;
         }
         // MSTOREA
         UME_FORCE_INLINE double* storea(SIMDVecMask<2> const & mask, double * p) const {
-            if (mask.mMask[0] == true) p[0] = mVec[0];
-            if (mask.mMask[1] == true) p[1] = mVec[1];
+            float64x2_t tmp = vld1q_f64(p);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, mVec, tmp);
+            vst1q_f64(p, tmp2);
             return p;
         }
 
         // BLENDV
         UME_FORCE_INLINE SIMDVec_f blend(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
-            double t0 = (mask.mMask[0] == true) ? b.mVec[0] : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? b.mVec[1] : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vbslq_f64(mask.mMask, b.mVec, mVec);
+            return SIMDVec_f(tmp);
         }
         // BLENDS
         UME_FORCE_INLINE SIMDVec_f blend(SIMDVecMask<2> const & mask, double b) const {
-            double t0 = (mask.mMask[0] == true) ? b : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? b : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // SWIZZLE
         // SWIZZLEA
 
         // ADDV
         UME_FORCE_INLINE SIMDVec_f add(SIMDVec_f const & b) const {
-            double t0 = mVec[0] + b.mVec[0];
-            double t1 = mVec[1] + b.mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vaddq_f64(mVec, b.mVec);
+            return SIMDVec_f(tmp);
         }
         UME_FORCE_INLINE SIMDVec_f operator+ (SIMDVec_f const & b) const {
             return add(b);
         }
         // MADDV
         UME_FORCE_INLINE SIMDVec_f add(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
-            double t0 = mask.mMask[0] ? mVec[0] + b.mVec[0] : mVec[0];
-            double t1 = mask.mMask[1] ? mVec[1] + b.mVec[1] : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vaddq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // ADDS
         UME_FORCE_INLINE SIMDVec_f add(double b) const {
-            double t0 = mVec[0] + b;
-            double t1 = mVec[1] + b;
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vaddq_f64(mVec, tmp);
+            return SIMDVec_f(tmp2);
         }
         UME_FORCE_INLINE SIMDVec_f operator+ (double b) const {
             return add(b);
         }
         // MADDS
         UME_FORCE_INLINE SIMDVec_f add(SIMDVecMask<2> const & mask, double b) const {
-            double t0 = mask.mMask[0] ? mVec[0] + b : mVec[0];
-            double t1 = mask.mMask[1] ? mVec[1] + b : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vaddq_f64(mVec, tmp);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
         // ADDVA
         UME_FORCE_INLINE SIMDVec_f & adda(SIMDVec_f const & b) {
-            mVec[0] += b.mVec[0];
-            mVec[1] += b.mVec[1];
+            mVec = vaddq_f64(mVec, b.mVec);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator+= (SIMDVec_f const & b) {
@@ -264,14 +269,14 @@ namespace SIMD {
         }
         // MADDVA
         UME_FORCE_INLINE SIMDVec_f & adda(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            mVec[0] = mask.mMask[0] ? mVec[0] + b.mVec[0] : mVec[0];
-            mVec[1] = mask.mMask[1] ? mVec[1] + b.mVec[1] : mVec[1];
+            float64x2_t tmp = vaddq_f64(mVec, b.mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
         // ADDSA
         UME_FORCE_INLINE SIMDVec_f & adda(double b) {
-            mVec[0] += b;
-            mVec[1] += b;
+            float64x2_t tmp = vdupq_n_f64(b);
+            mVec = vaddq_f64(mVec, tmp);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator+= (double b) {
@@ -279,8 +284,9 @@ namespace SIMD {
         }
         // MADDSA
         UME_FORCE_INLINE SIMDVec_f & adda(SIMDVecMask<2> const & mask, double b) {
-            mVec[0] = mask.mMask[0] ? mVec[0] + b : mVec[0];
-            mVec[1] = mask.mMask[1] ? mVec[1] + b : mVec[1];
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vaddq_f64(mVec, tmp);
+            mVec = vbslq_f64(mask.mMask, tmp2, mVec);
             return *this;
         }
         // SADDV
@@ -293,23 +299,26 @@ namespace SIMD {
         // MSADDSA
         // POSTINC
         UME_FORCE_INLINE SIMDVec_f postinc() {
-            double t0 = mVec[0]++;
-            double t1 = mVec[1]++;
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(1.0);
+            float64x2_t tmp2 = mVec;
+            mVec = vaddq_f64(mVec, tmp);
+            return SIMDVec_f(tmp2);
         }
         UME_FORCE_INLINE SIMDVec_f operator++ (int) {
             return postinc();
         }
         // MPOSTINC
         UME_FORCE_INLINE SIMDVec_f postinc(SIMDVecMask<2> const & mask) {
-            double t0 = (mask.mMask[0] == true) ? mVec[0]++ : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? mVec[1]++ : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(1.0);
+            float64x2_t tmp2 = mVec;
+            float64x2_t tmp3 = vaddq_f64(mVec, tmp);
+            mVec = vbslq_f64(mask.mMask, tmp3, mVec);
+            return SIMDVec_f(tmp2);
         }
         // PREFINC
         UME_FORCE_INLINE SIMDVec_f & prefinc() {
-            mVec[0]++;
-            mVec[1]++;
+            float64x2_t tmp = vdupq_n_f64(1.0);
+            mVec = vaddq_f64(mVec, tmp);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator++ () {
@@ -317,44 +326,44 @@ namespace SIMD {
         }
         // MPREFINC
         UME_FORCE_INLINE SIMDVec_f & prefinc(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) ++mVec[0];
-            if (mask.mMask[1] == true) ++mVec[1];
+            float64x2_t tmp = vdupq_n_f64(1.0);
+            float64x2_t tmp2 = vaddq_f64(mVec, tmp);
+            mVec = vbslq_f64(mask.mMask, tmp2, mVec);
             return *this;
         }
         // SUBV
         UME_FORCE_INLINE SIMDVec_f sub(SIMDVec_f const & b) const {
-            double t0 = mVec[0] - b.mVec[0];
-            double t1 = mVec[1] - b.mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vsubq_f64(mVec, b.mVec);
+            return SIMDVec_f(tmp);
         }
         UME_FORCE_INLINE SIMDVec_f operator- (SIMDVec_f const & b) const {
             return sub(b);
         }
         // MSUBV
         UME_FORCE_INLINE SIMDVec_f sub(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
-            double t0 = (mask.mMask[0] == true) ? (mVec[0] - b.mVec[0]) : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? (mVec[1] - b.mVec[1]) : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vsubq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // SUBS
         UME_FORCE_INLINE SIMDVec_f sub(double b) const {
-            double t0 = mVec[0] - b;
-            double t1 = mVec[1] - b;
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vsubq_f64(mVec, tmp);
+            return SIMDVec_f(tmp2);
         }
         UME_FORCE_INLINE SIMDVec_f operator- (double b) const {
             return sub(b);
         }
         // MSUBS
         UME_FORCE_INLINE SIMDVec_f sub(SIMDVecMask<2> const & mask, double b) const {
-            double t0 = (mask.mMask[0] == true) ? (mVec[0] - b) : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? (mVec[1] - b) : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vsubq_f64(mVec, tmp);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
         // SUBVA
         UME_FORCE_INLINE SIMDVec_f & suba(SIMDVec_f const & b) {
-            mVec[0] = mVec[0] - b.mVec[0];
-            mVec[1] = mVec[1] - b.mVec[1];
+            mVec = vsubq_f64(mVec, b.mVec);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator-= (SIMDVec_f const & b) {
@@ -362,14 +371,14 @@ namespace SIMD {
         }
         // MSUBVA
         UME_FORCE_INLINE SIMDVec_f & suba(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true) mVec[0] = mVec[0] - b.mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = mVec[1] - b.mVec[1];
+            float64x2_t tmp = vsubq_f64(mVec, b.mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
         // SUBSA
         UME_FORCE_INLINE SIMDVec_f & suba(const double b) {
-            mVec[0] = mVec[0] - b;
-            mVec[1] = mVec[1] - b;
+            float64x2_t tmp = vdupq_n_f64(b);
+            mVec = vsubq_f64(mVec, tmp);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator-= (double b) {
@@ -377,8 +386,9 @@ namespace SIMD {
         }
         // MSUBSA
         UME_FORCE_INLINE SIMDVec_f & suba(SIMDVecMask<2> const & mask, const double b) {
-            if (mask.mMask[0] == true) mVec[0] = mVec[0] - b;
-            if (mask.mMask[1] == true) mVec[1] = mVec[1] - b;
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vsubq_f64(mVec, tmp);
+            mVec = vbslq_f64(mask.mMask, tmp2, mVec);
             return *this;
         }
         // SSUBV
@@ -391,71 +401,74 @@ namespace SIMD {
         // MSSUBSA
         // SUBFROMV
         UME_FORCE_INLINE SIMDVec_f subfrom(SIMDVec_f const & a) const {
-            double t0 = a.mVec[0] - mVec[0];
-            double t1 = a.mVec[1] - mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vsubq_f64(a.mVec, mVec);
+            return SIMDVec_f(tmp);
         }
         // MSUBFROMV
         UME_FORCE_INLINE SIMDVec_f subfrom(SIMDVecMask<2> const & mask, SIMDVec_f const & a) const {
-            double t0 = (mask.mMask[0] == true) ? (a.mVec[0] - mVec[0]) : a[0];
-            double t1 = (mask.mMask[1] == true) ? (a.mVec[1] - mVec[1]) : a[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vsubq_f64(a.mVec, mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, a.mVec, tmp);
+            return SIMDVec_f(tmp2);
         }
         // SUBFROMS
         UME_FORCE_INLINE SIMDVec_f subfrom(double a) const {
-            double t0 = a - mVec[0];
-            double t1 = a - mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(a);
+            float64x2_t tmp2 = vsubq_f64(tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // MSUBFROMS
         UME_FORCE_INLINE SIMDVec_f subfrom(SIMDVecMask<2> const & mask, double a) const {
-            double t0 = (mask.mMask[0] == true) ? (a - mVec[0]) : a;
-            double t1 = (mask.mMask[1] == true) ? (a - mVec[1]) : a;
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(a);
+            float64x2_t tmp2 = vsubq_f64(tmp, mVec);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp, tmp2);
+            return SIMDVec_f(tmp3);
         }
         // SUBFROMVA
         UME_FORCE_INLINE SIMDVec_f & subfroma(SIMDVec_f const & a) {
-            mVec[0] = a.mVec[0] - mVec[0];
-            mVec[1] = a.mVec[1] - mVec[1];
+            mVec = vsubq_f64(a.mVec, mVec);
             return *this;
         }
         // MSUBFROMVA
         UME_FORCE_INLINE SIMDVec_f & subfroma(SIMDVecMask<2> const & mask, SIMDVec_f const & a) {
-            mVec[0] = (mask.mMask[0] == true) ? (a.mVec[0] - mVec[0]) : a.mVec[0];
-            mVec[1] = (mask.mMask[1] == true) ? (a.mVec[1] - mVec[1]) : a.mVec[1];
+            float64x2_t tmp = vsubq_f64(a.mVec, mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, a.mVec);
             return *this;
         }
         // SUBFROMSA
         UME_FORCE_INLINE SIMDVec_f & subfroma(double a) {
-            mVec[0] = a - mVec[0];
-            mVec[1] = a - mVec[1];
+            float64x2_t tmp = vdupq_n_f64(a);
+            mVec = vsubq_f64(tmp, mVec);
             return *this;
         }
         // MSUBFROMSA
         UME_FORCE_INLINE SIMDVec_f & subfroma(SIMDVecMask<2> const & mask, double a) {
-            mVec[0] = (mask.mMask[0] == true) ? (a - mVec[0]) : a;
-            mVec[1] = (mask.mMask[1] == true) ? (a - mVec[1]) : a;
+            float64x2_t tmp = vdupq_n_f64(a);
+            float64x2_t tmp2 = vsubq_f64(tmp, mVec);
+            mVec = vbslq_f64(mask.mMask, tmp2, tmp);
             return *this;
         }
         // POSTDEC
         UME_FORCE_INLINE SIMDVec_f postdec() {
-            double t0 = mVec[0]--;
-            double t1 = mVec[1]--;
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(1.0);
+            float64x2_t tmp2 = mVec;
+            mVec = vsubq_f64(mVec, tmp);
+            return SIMDVec_f(tmp2);
         }
         UME_FORCE_INLINE SIMDVec_f operator-- (int) {
             return postdec();
         }
         // MPOSTDEC
         UME_FORCE_INLINE SIMDVec_f postdec(SIMDVecMask<2> const & mask) {
-            double t0 = (mask.mMask[0] == true) ? mVec[0]-- : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? mVec[1]-- : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(1.0);
+            float64x2_t tmp2 = mVec;
+            float64x2_t tmp3 = vsubq_f64(mVec, tmp);
+            mVec = vbslq_f64(mask.mMask, tmp3, mVec);
+            return SIMDVec_f(tmp2);
         }
         // PREFDEC
         UME_FORCE_INLINE SIMDVec_f & prefdec() {
-            --mVec[0];
-            --mVec[1];
+            float64x2_t tmp = vdupq_n_f64(1.0);
+            mVec = vsubq_f64(mVec, tmp);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator-- () {
@@ -463,44 +476,44 @@ namespace SIMD {
         }
         // MPREFDEC
         UME_FORCE_INLINE SIMDVec_f & prefdec(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) --mVec[0];
-            if (mask.mMask[1] == true) --mVec[1];
+            float64x2_t tmp = vdupq_n_f64(1.0);
+            float64x2_t tmp2 = vsubq_f64(mVec, tmp);
+            mVec = vbslq_f64(mask.mMask, tmp2, mVec);
             return *this;
         }
         // MULV
         UME_FORCE_INLINE SIMDVec_f mul(SIMDVec_f const & b) const {
-            double t0 = mVec[0] * b.mVec[0];
-            double t1 = mVec[1] * b.mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vmulq_f64(mVec, b.mVec);
+            return SIMDVec_f(tmp);
         }
         UME_FORCE_INLINE SIMDVec_f operator* (SIMDVec_f const & b) const {
             return mul(b);
         }
         // MMULV
         UME_FORCE_INLINE SIMDVec_f mul(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
-            double t0 = mask.mMask[0] ? mVec[0] * b.mVec[0] : mVec[0];
-            double t1 = mask.mMask[1] ? mVec[1] * b.mVec[1] : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vmulq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // MULS
         UME_FORCE_INLINE SIMDVec_f mul(double b) const {
-            double t0 = mVec[0] * b;
-            double t1 = mVec[1] * b;
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2= vmulq_f64(mVec, tmp);
+            return SIMDVec_f(tmp2);
         }
         UME_FORCE_INLINE SIMDVec_f operator* (double b) const {
             return mul(b);
         }
         // MMULS
         UME_FORCE_INLINE SIMDVec_f mul(SIMDVecMask<2> const & mask, double b) const {
-            double t0 = mask.mMask[0] ? mVec[0] * b : mVec[0];
-            double t1 = mask.mMask[1] ? mVec[1] * b : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2= vmulq_f64(mVec, tmp);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
         // MULVA
         UME_FORCE_INLINE SIMDVec_f & mula(SIMDVec_f const & b) {
-            mVec[0] *= b.mVec[0];
-            mVec[1] *= b.mVec[1];
+            mVec = vmulq_f64(mVec, b.mVec);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator*= (SIMDVec_f const & b) {
@@ -508,14 +521,14 @@ namespace SIMD {
         }
         // MMULVA
         UME_FORCE_INLINE SIMDVec_f & mula(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true) mVec[0] *= b.mVec[0];
-            if (mask.mMask[1] == true) mVec[1] *= b.mVec[1];
+            float64x2_t tmp = vmulq_f64(mVec, b.mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
         // MULSA
         UME_FORCE_INLINE SIMDVec_f & mula(double b) {
-            mVec[0] *= b;
-            mVec[1] *= b;
+            float64x2_t tmp = vdupq_n_f64(b);
+            mVec = vmulq_f64(mVec, tmp);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator*= (double b) {
@@ -523,44 +536,44 @@ namespace SIMD {
         }
         // MMULSA
         UME_FORCE_INLINE SIMDVec_f & mula(SIMDVecMask<2> const & mask, double b) {
-            if (mask.mMask[0] == true) mVec[0] *= b;
-            if (mask.mMask[1] == true) mVec[1] *= b;
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2= vmulq_f64(mVec, tmp);
+            mVec = vbslq_f64(mask.mMask, tmp2, mVec);
             return *this;
         }
         // DIVV
         UME_FORCE_INLINE SIMDVec_f div(SIMDVec_f const & b) const {
-            double t0 = mVec[0] / b.mVec[0];
-            double t1 = mVec[1] / b.mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdivq_f64(mVec, b.mVec);
+            return SIMDVec_f(tmp);
         }
         UME_FORCE_INLINE SIMDVec_f operator/ (SIMDVec_f const & b) const {
             return div(b);
         }
         // MDIVV
         UME_FORCE_INLINE SIMDVec_f div(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
-            double t0 = mask.mMask[0] ? mVec[0] / b.mVec[0] : mVec[0];
-            double t1 = mask.mMask[1] ? mVec[1] / b.mVec[1] : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdivq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // DIVS
         UME_FORCE_INLINE SIMDVec_f div(double b) const {
-            double t0 = mVec[0] / b;
-            double t1 = mVec[1] / b;
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2= vdivq_f64(mVec, tmp);
+            return SIMDVec_f(tmp2);
         }
         UME_FORCE_INLINE SIMDVec_f operator/ (double b) const {
             return div(b);
         }
         // MDIVS
         UME_FORCE_INLINE SIMDVec_f div(SIMDVecMask<2> const & mask, double b) const {
-            double t0 = mask.mMask[0] ? mVec[0] / b : mVec[0];
-            double t1 = mask.mMask[1] ? mVec[1] / b : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2= vdivq_f64(mVec, tmp);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
         // DIVVA
         UME_FORCE_INLINE SIMDVec_f & diva(SIMDVec_f const & b) {
-            mVec[0] /= b.mVec[0];
-            mVec[1] /= b.mVec[1];
+            mVec = vdivq_f64(mVec, b.mVec);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator/= (SIMDVec_f const & b) {
@@ -568,14 +581,14 @@ namespace SIMD {
         }
         // MDIVVA
         UME_FORCE_INLINE SIMDVec_f & diva(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true) mVec[0] /= b.mVec[0];
-            if (mask.mMask[1] == true) mVec[1] /= b.mVec[1];
+            float64x2_t tmp = vdivq_f64(mVec, b.mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
         // DIVSA
         UME_FORCE_INLINE SIMDVec_f & diva(double b) {
-            mVec[0] /= b;
-            mVec[1] /= b;
+            float64x2_t tmp = vdupq_n_f64(b);
+            mVec = vdivq_f64(mVec, tmp);
             return *this;
         }
         UME_FORCE_INLINE SIMDVec_f & operator/= (double b) {
@@ -583,559 +596,520 @@ namespace SIMD {
         }
         // MDIVSA
         UME_FORCE_INLINE SIMDVec_f & diva(SIMDVecMask<2> const & mask, double b) {
-            if (mask.mMask[0] == true) mVec[0] /= b;
-            if (mask.mMask[1] == true) mVec[1] /= b;
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2= vdivq_f64(mVec, tmp);
+            mVec = vbslq_f64(mask.mMask, tmp2, mVec);
             return *this;
         }
         // RCP
         UME_FORCE_INLINE SIMDVec_f rcp() const {
-            double t0 = 1.0f / mVec[0];
-            double t1 = 1.0f / mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vrecpeq_f64(mVec);
+            return SIMDVec_f(tmp);
         }
         // MRCP
         UME_FORCE_INLINE SIMDVec_f rcp(SIMDVecMask<2> const & mask) const {
-            double t0 = mask.mMask[0] ? 1.0f / mVec[0] : mVec[0];
-            double t1 = mask.mMask[1] ? 1.0f / mVec[1] : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vrecpeq_f64(mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // RCPS
         UME_FORCE_INLINE SIMDVec_f rcp(double b) const {
-            double t0 = b / mVec[0];
-            double t1 = b / mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2= vdivq_f64(tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // MRCPS
         UME_FORCE_INLINE SIMDVec_f rcp(SIMDVecMask<2> const & mask, double b) const {
-            double t0 = mask.mMask[0] ? b / mVec[0] : mVec[0];
-            double t1 = mask.mMask[1] ? b / mVec[1] : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2= vdivq_f64(tmp, mVec);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
         // RCPA
         UME_FORCE_INLINE SIMDVec_f & rcpa() {
-            mVec[0] = 1.0f / mVec[0];
-            mVec[1] = 1.0f / mVec[1];
+            mVec = vrecpeq_f64(mVec);
             return *this;
         }
         // MRCPA
         UME_FORCE_INLINE SIMDVec_f & rcpa(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) mVec[0] = 1.0f / mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = 1.0f / mVec[1];
+            float64x2_t tmp = vrecpeq_f64(mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
         // RCPSA
         UME_FORCE_INLINE SIMDVec_f & rcpa(double b) {
-            mVec[0] = b / mVec[0];
-            mVec[1] = b / mVec[1];
+            float64x2_t tmp = vdupq_n_f64(b);
+            mVec = vdivq_f64(tmp, mVec);
             return *this;
         }
         // MRCPSA
         UME_FORCE_INLINE SIMDVec_f & rcpa(SIMDVecMask<2> const & mask, double b) {
-            if (mask.mMask[0] == true) mVec[0] = b / mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = b / mVec[1];
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2= vdivq_f64(tmp, mVec);
+            mVec = vbslq_f64(mask.mMask, tmp2, mVec);
             return *this;
         }
 
         // CMPEQV
         UME_FORCE_INLINE SIMDVecMask<2> cmpeq(SIMDVec_f const & b) const {
-            bool m0 = mVec[0] == b.mVec[0];
-            bool m1 = mVec[1] == b.mVec[1];
-            return SIMDVecMask<2>(m0, m1);
+            uint64x2_t tmp = vceqq_f64(mVec, b.mVec);
+            return SIMDVecMask<2>(tmp);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator== (SIMDVec_f const & b) const {
             return cmpeq(b);
         }
         // CMPEQS
         UME_FORCE_INLINE SIMDVecMask<2> cmpeq(double b) const {
-            bool m0 = mVec[0] == b;
-            bool m1 = mVec[1] == b;
-            return SIMDVecMask<2>(m0, m1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            uint64x2_t tmp2 = vceqq_f64(mVec, tmp);
+            return SIMDVecMask<2>(tmp2);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator== (double b) const {
             return cmpeq(b);
         }
         // CMPNEV
         UME_FORCE_INLINE SIMDVecMask<2> cmpne(SIMDVec_f const & b) const {
-            bool m0 = mVec[0] != b.mVec[0];
-            bool m1 = mVec[1] != b.mVec[1];
-            return SIMDVecMask<2>(m0, m1);
+            uint64x2_t tmp = vceqq_f64(mVec, b.mVec);
+            uint64x2_t tmp2 =  vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(tmp)));
+            return SIMDVecMask<2>(tmp2);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator!= (SIMDVec_f const & b) const {
             return cmpne(b);
         }
         // CMPNES
         UME_FORCE_INLINE SIMDVecMask<2> cmpne(double b) const {
-            bool m0 = mVec[0] != b;
-            bool m1 = mVec[1] != b;
-            return SIMDVecMask<2>(m0, m1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            uint64x2_t tmp2 = vceqq_f64(mVec, tmp);
+            uint64x2_t tmp3 = vreinterpretq_u64_u32(vmvnq_u32(vreinterpretq_u32_u64(tmp2)));
+            return SIMDVecMask<2>(tmp3);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator!= (double b) const {
             return cmpne(b);
         }
         // CMPGTV
         UME_FORCE_INLINE SIMDVecMask<2> cmpgt(SIMDVec_f const & b) const {
-            bool m0 = mVec[0] > b.mVec[0];
-            bool m1 = mVec[1] > b.mVec[1];
-            return SIMDVecMask<2>(m0, m1);
+            uint64x2_t tmp =vcgtq_f64(mVec, b.mVec);
+            return SIMDVecMask<2>(tmp);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator> (SIMDVec_f const & b) const {
             return cmpgt(b);
         }
         // CMPGTS
         UME_FORCE_INLINE SIMDVecMask<2> cmpgt(double b) const {
-            bool m0 = mVec[0] > b;
-            bool m1 = mVec[1] > b;
-            return SIMDVecMask<2>(m0, m1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            uint64x2_t tmp2 = vcgtq_f64(mVec, tmp);
+            return SIMDVecMask<2>(tmp2);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator> (double b) const {
             return cmpgt(b);
         }
         // CMPLTV
         UME_FORCE_INLINE SIMDVecMask<2> cmplt(SIMDVec_f const & b) const {
-            bool m0 = mVec[0] < b.mVec[0];
-            bool m1 = mVec[1] < b.mVec[1];
-            return SIMDVecMask<2>(m0, m1);
+            uint64x2_t tmp =vcltq_f64(mVec, b.mVec);
+            return SIMDVecMask<2>(tmp);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator< (SIMDVec_f const & b) const {
             return cmplt(b);
         }
         // CMPLTS
         UME_FORCE_INLINE SIMDVecMask<2> cmplt(double b) const {
-            bool m0 = mVec[0] < b;
-            bool m1 = mVec[1] < b;
-            return SIMDVecMask<2>(m0, m1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            uint64x2_t tmp2 =vcltq_f64(mVec, tmp);
+            return SIMDVecMask<2>(tmp2);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator< (double b) const {
             return cmplt(b);
         }
         // CMPGEV
         UME_FORCE_INLINE SIMDVecMask<2> cmpge(SIMDVec_f const & b) const {
-            SIMDVecMask<2> mask;
-            mask.mMask[0] = mVec[0] >= b.mVec[0];
-            mask.mMask[1] = mVec[1] >= b.mVec[1];
-            return mask;
+            uint64x2_t tmp =vcgeq_f64(mVec, b.mVec);
+            return SIMDVecMask<2>(tmp);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator>= (SIMDVec_f const & b) const {
             return cmpge(b);
         }
         // CMPGES
         UME_FORCE_INLINE SIMDVecMask<2> cmpge(double b) const {
-            SIMDVecMask<2> mask;
-            mask.mMask[0] = mVec[0] >= b;
-            mask.mMask[1] = mVec[1] >= b;
-            return mask;
+            float64x2_t tmp = vdupq_n_f64(b);
+            uint64x2_t tmp2 =vcgeq_f64(mVec, tmp);
+            return SIMDVecMask<2>(tmp2);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator>= (double b) const {
             return cmpge(b);
         }
         // CMPLEV
         UME_FORCE_INLINE SIMDVecMask<2> cmple(SIMDVec_f const & b) const {
-            SIMDVecMask<2> mask;
-            mask.mMask[0] = mVec[0] <= b.mVec[0];
-            mask.mMask[1] = mVec[1] <= b.mVec[1];
-            return mask;
+            uint64x2_t tmp =vcleq_f64(mVec, b.mVec);
+            return SIMDVecMask<2>(tmp);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator<= (SIMDVec_f const & b) const {
             return cmple(b);
         }
         // CMPLES
         UME_FORCE_INLINE SIMDVecMask<2> cmple(double b) const {
-            SIMDVecMask<2> mask;
-            mask.mMask[0] = mVec[0] <= b;
-            mask.mMask[1] = mVec[1] <= b;
-            return mask;
+            float64x2_t tmp = vdupq_n_f64(b);
+            uint64x2_t tmp2 =vcleq_f64(mVec, tmp);
+            return SIMDVecMask<2>(tmp2);
         }
         UME_FORCE_INLINE SIMDVecMask<2> operator<= (double b) const {
             return cmple(b);
         }
         // CMPEV
         UME_FORCE_INLINE bool cmpe(SIMDVec_f const & b) const {
-            bool m0 = mVec[0] == b.mVec[0];
-            bool m1 = mVec[0] == b.mVec[1];
-            return m0 && m1;
+            uint64x2_t tmp = vceqq_f64(mVec, b.mVec);
+            uint32_t tmp2 = vminvq_u32(vreinterpretq_u32_u64(tmp));
+            return tmp2 != 0;
         }
         // CMPES
         UME_FORCE_INLINE bool cmpe(double b) const {
-            bool m0 = mVec[0] == b;
-            bool m1 = mVec[1] == b;
-            return m0 && m1;
+            float64x2_t tmp = vdupq_n_f64(b);
+            uint64x2_t tmp2 = vceqq_f64(mVec, tmp);
+            uint32_t tmp3 = vminvq_u32(vreinterpretq_u32_u64(tmp2));
+            return tmp3 != 0;
         }
         // UNIQUE
-        UME_FORCE_INLINE bool unique() const {
-            return mVec[0] != mVec[1];
-        }
+//        UME_FORCE_INLINE bool unique() const {
+//            return mVec[0] != mVec[1];
+//        }
         // HADD
-        UME_FORCE_INLINE double hadd() const {
-            return mVec[0] + mVec[1];
-        }
-        // MHADD
-        UME_FORCE_INLINE double hadd(SIMDVecMask<2> const & mask) const {
-            double t0 = mask.mMask[0] ? mVec[0] : 0;
-            double t1 = mask.mMask[1] ? mVec[1] : 0;
-            return t0 + t1;
-        }
-        // HADDS
-        UME_FORCE_INLINE double hadd(double b) const {
-            return b + mVec[0] + mVec[1];
-        }
-        // MHADDS
-        UME_FORCE_INLINE double hadd(SIMDVecMask<2> const & mask, double b) const {
-            double t0 = mask.mMask[0] ? mVec[0] + b : b;
-            double t1 = mask.mMask[1] ? mVec[1] + t0 : t0;
-            return t1;
-        }
-        // HMUL
-        UME_FORCE_INLINE double hmul() const {
-            return mVec[0] * mVec[1];
-        }
-        // MHMUL
-        UME_FORCE_INLINE double hmul(SIMDVecMask<2> const & mask) const {
-            double t0 = mask.mMask[0] ? mVec[0] : 1;
-            double t1 = mask.mMask[1] ? mVec[1]*t0 : t0;
-            return t1;
-        }
-        // HMULS
-        UME_FORCE_INLINE double hmul(double b) const {
-            return b * mVec[0] * mVec[1];
-        }
-        // MHMULS
-        UME_FORCE_INLINE double hmul(SIMDVecMask<2> const & mask, double b) const {
-            double t0 = mask.mMask[0] ? mVec[0] * b : b;
-            double t1 = mask.mMask[1] ? mVec[1] * t0 : t0;
-            return t1;
-        }
+//        UME_FORCE_INLINE double hadd() const {
+//            return vaddvq_f64(mVec); // not available wit hgcc
+//        }
+//        // MHADD
+//        UME_FORCE_INLINE double hadd(SIMDVecMask<2> const & mask) const {
+//            double t0 = mask.mMask[0] ? mVec[0] : 0;
+//            double t1 = mask.mMask[1] ? mVec[1] : 0;
+//            return t0 + t1;
+//        }
+//        // HADDS
+//        UME_FORCE_INLINE double hadd(double b) const {
+//            return b + mVec[0] + mVec[1];
+//        }
+//        // MHADDS
+//        UME_FORCE_INLINE double hadd(SIMDVecMask<2> const & mask, double b) const {
+//            double t0 = mask.mMask[0] ? mVec[0] + b : b;
+//            double t1 = mask.mMask[1] ? mVec[1] + t0 : t0;
+//            return t1;
+//        }
+//        // HMUL
+//        UME_FORCE_INLINE double hmul() const {
+//            return mVec[0] * mVec[1];
+//        }
+//        // MHMUL
+//        UME_FORCE_INLINE double hmul(SIMDVecMask<2> const & mask) const {
+//            double t0 = mask.mMask[0] ? mVec[0] : 1;
+//            double t1 = mask.mMask[1] ? mVec[1]*t0 : t0;
+//            return t1;
+//        }
+//        // HMULS
+//        UME_FORCE_INLINE double hmul(double b) const {
+//            return b * mVec[0] * mVec[1];
+//        }
+//        // MHMULS
+//        UME_FORCE_INLINE double hmul(SIMDVecMask<2> const & mask, double b) const {
+//            double t0 = mask.mMask[0] ? mVec[0] * b : b;
+//            double t1 = mask.mMask[1] ? mVec[1] * t0 : t0;
+//            return t1;
+//        }
 
         // FMULADDV
         UME_FORCE_INLINE SIMDVec_f fmuladd(SIMDVec_f const & b, SIMDVec_f const & c) const {
-            double t0 = mVec[0] * b.mVec[0] + c.mVec[0];
-            double t1 = mVec[1] * b.mVec[1] + c.mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vfmaq_f64(c.mVec, mVec, b.mVec);
+            return SIMDVec_f(tmp);
         }
         // MFMULADDV
         UME_FORCE_INLINE SIMDVec_f fmuladd(SIMDVecMask<2> const & mask, SIMDVec_f const & b, SIMDVec_f const & c) const {
-            double t0 = (mask.mMask[0] == true) ? (mVec[0] * b.mVec[0] + c.mVec[0]) : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? (mVec[1] * b.mVec[1] + c.mVec[1]) : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vfmaq_f64(c.mVec, mVec, b.mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // FMULSUBV
         UME_FORCE_INLINE SIMDVec_f fmulsub(SIMDVec_f const & b, SIMDVec_f const & c) const {
-            double t0 = mVec[0] * b.mVec[0] - c.mVec[0];
-            double t1 = mVec[1] * b.mVec[1] - c.mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vmulq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vsubq_f64(tmp, c.mVec);
+            return SIMDVec_f(tmp2);
         }
         // MFMULSUBV
         UME_FORCE_INLINE SIMDVec_f fmulsub(SIMDVecMask<2> const & mask, SIMDVec_f const & b, SIMDVec_f const & c) const {
-            double t0 = (mask.mMask[0] == true) ? (mVec[0] * b.mVec[0] - c.mVec[0]) : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? (mVec[1] * b.mVec[1] - c.mVec[1]) : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vmulq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vsubq_f64(tmp, c.mVec);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
         // FADDMULV
         UME_FORCE_INLINE SIMDVec_f faddmul(SIMDVec_f const & b, SIMDVec_f const & c) const {
-            double t0 = (mVec[0] + b.mVec[0]) * c.mVec[0];
-            double t1 = (mVec[1] + b.mVec[1]) * c.mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vaddq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vmulq_f64(tmp, c.mVec);
+            return SIMDVec_f(tmp2);
         }
         // MFADDMULV
         UME_FORCE_INLINE SIMDVec_f faddmul(SIMDVecMask<2> const & mask, SIMDVec_f const & b, SIMDVec_f const & c) const {
-            double t0 = (mask.mMask[0] == true) ? ((mVec[0] + b.mVec[0]) * c.mVec[0]) : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? ((mVec[1] + b.mVec[1]) * c.mVec[1]) : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vaddq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vmulq_f64(tmp, c.mVec);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
         // FSUBMULV
         UME_FORCE_INLINE SIMDVec_f fsubmul(SIMDVec_f const & b, SIMDVec_f const & c) const {
-            double t0 = (mVec[0] - b.mVec[0]) * c.mVec[0];
-            double t1 = (mVec[1] - b.mVec[1]) * c.mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vsubq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vmulq_f64(tmp, c.mVec);
+            return SIMDVec_f(tmp2);
         }
         // MFSUBMULV
         UME_FORCE_INLINE SIMDVec_f fsubmul(SIMDVecMask<2> const & mask, SIMDVec_f const & b, SIMDVec_f const & c) const {
-            double t0 = (mask.mMask[0] == true) ? ((mVec[0] - b.mVec[0]) * c.mVec[0]) : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? ((mVec[1] - b.mVec[1]) * c.mVec[1]) : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vsubq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vmulq_f64(tmp, c.mVec);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
 
         // MAXV
         UME_FORCE_INLINE SIMDVec_f max(SIMDVec_f const & b) const {
-            double t0 = mVec[0] > b.mVec[0] ? mVec[0] : b.mVec[0];
-            double t1 = mVec[1] > b.mVec[1] ? mVec[1] : b.mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vmaxq_f64(mVec, b.mVec);
+            return SIMDVec_f(tmp);
         }
         // MMAXV
         UME_FORCE_INLINE SIMDVec_f max(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
-            double t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
-                t0 = (mVec[0] > b.mVec[0]) ? mVec[0] : b.mVec[0];
-            }
-            if (mask.mMask[1] == true) {
-                t1 = (mVec[1] > b.mVec[1]) ? mVec[1] : b.mVec[1];
-            }
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vmaxq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // MAXS
         UME_FORCE_INLINE SIMDVec_f max(double b) const {
-            double t0 = mVec[0] > b ? mVec[0] : b;
-            double t1 = mVec[1] > b ? mVec[1] : b;
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vmaxq_f64(mVec, tmp);
+            return SIMDVec_f(tmp2);
         }
         // MMAXS
         UME_FORCE_INLINE SIMDVec_f max(SIMDVecMask<2> const & mask, double b) const {
-            double t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
-                t0 = (mVec[0] > b) ? mVec[0] : b;
-            }
-            if (mask.mMask[1] == true) {
-                t1 = (mVec[1] > b) ? mVec[1] : b;
-            }
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vmaxq_f64(mVec, tmp);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
         // MAXVA
         UME_FORCE_INLINE SIMDVec_f & maxa(SIMDVec_f const & b) {
-            if (mVec[0] < b.mVec[0]) mVec[0] = b.mVec[0];
-            if (mVec[1] < b.mVec[1]) mVec[1] = b.mVec[1];
+            mVec = vmaxq_f64(mVec, b.mVec);
             return *this;
         }
         // MMAXVA
         UME_FORCE_INLINE SIMDVec_f & maxa(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true && mVec[0] < b.mVec[0]) {
-                mVec[0] = b.mVec[0];
-            }
-            if (mask.mMask[1] == true && mVec[1] < b.mVec[1]) {
-                mVec[1] = b.mVec[1];
-            }
+            float64x2_t tmp = vmaxq_f64(mVec, b.mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
         // MAXSA
         UME_FORCE_INLINE SIMDVec_f & maxa(double b) {
-            mVec[0] = mVec[0] > b ? mVec[0] : b;
-            mVec[1] = mVec[1] > b ? mVec[1] : b;
+            float64x2_t tmp = vdupq_n_f64(b);
+            mVec = vmaxq_f64(mVec, tmp);
             return *this;
         }
         // MMAXSA
         UME_FORCE_INLINE SIMDVec_f & maxa(SIMDVecMask<2> const & mask, double b) {
-            if (mask.mMask[0] == true && mVec[0] < b) {
-                mVec[0] = b;
-            }
-            if (mask.mMask[1] == true && mVec[1] < b) {
-                mVec[1] = b;
-            }
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vmaxq_f64(mVec, tmp);
+            mVec = vbslq_f64(mask.mMask, tmp2, mVec);
             return *this;
         }
         // MINV
         UME_FORCE_INLINE SIMDVec_f min(SIMDVec_f const & b) const {
-            double t0 = mVec[0] < b.mVec[0] ? mVec[0] : b.mVec[0];
-            double t1 = mVec[1] < b.mVec[1] ? mVec[1] : b.mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vminq_f64(mVec, b.mVec);
+            return SIMDVec_f(tmp);
         }
         // MMINV
         UME_FORCE_INLINE SIMDVec_f min(SIMDVecMask<2> const & mask, SIMDVec_f const & b) const {
-            double t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
-                t0 = (mVec[0] < b.mVec[0]) ? mVec[0] : b.mVec[0];
-            }
-            if (mask.mMask[1] == true) {
-                t1 = (mVec[1] < b.mVec[1]) ? mVec[1] : b.mVec[1];
-            }
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vminq_f64(mVec, b.mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // MINS
         UME_FORCE_INLINE SIMDVec_f min(double b) const {
-            double t0 = mVec[0] < b ? mVec[0] : b;
-            double t1 = mVec[1] < b ? mVec[1] : b;
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vminq_f64(mVec, tmp);
+            return SIMDVec_f(tmp2);
         }
         // MMINS
         UME_FORCE_INLINE SIMDVec_f min(SIMDVecMask<2> const & mask, double b) const {
-            double t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
-                t0 = mVec[0] < b ? mVec[0] : b;
-            }
-            if (mask.mMask[1] == true) {
-                t1 = mVec[1] < b ? mVec[1] : b;
-            }
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vdupq_n_f64(b);
+            float64x2_t tmp2 = vminq_f64(mVec, tmp);
+            float64x2_t tmp3 = vbslq_f64(mask.mMask, tmp2, mVec);
+            return SIMDVec_f(tmp3);
         }
         // MINVA
         UME_FORCE_INLINE SIMDVec_f & mina(SIMDVec_f const & b) {
-            if(mVec[0] > b.mVec[0]) mVec[0] = b.mVec[0];
-            if(mVec[1] > b.mVec[1]) mVec[1] = b.mVec[1];
+            mVec = vminq_f64(mVec, b.mVec);
             return *this;
         }
         // MMINVA
         UME_FORCE_INLINE SIMDVec_f & mina(SIMDVecMask<2> const & mask, SIMDVec_f const & b) {
-            if (mask.mMask[0] == true && mVec[0] > b.mVec[0]) {
-                mVec[0] = b.mVec[0];
-            }
-            if (mask.mMask[1] == true && mVec[1] > b.mVec[1]) {
-                mVec[1] = b.mVec[1];
-            }
+            float64x2_t tmp = vminq_f64(mVec, b.mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
-        // MINSA
-        UME_FORCE_INLINE SIMDVec_f & mina(double b) {
-            if(mVec[0] > b) mVec[0] = b;
-            if(mVec[1] > b) mVec[1] = b;
-            return *this;
-        }
-        // MMINSA
-        UME_FORCE_INLINE SIMDVec_f & mina(SIMDVecMask<2> const & mask, double b) {
-            if (mask.mMask[0] == true && mVec[0] > b) {
-                mVec[0] = b;
-            }
-            if (mask.mMask[1] == true && mVec[1] > b) {
-                mVec[1] = b;
-            }
-            return *this;
-        }
-        // HMAX
-        UME_FORCE_INLINE double hmax() const {
-            return mVec[0] > mVec[1] ? mVec[0] : mVec[1];
-        }
-        // MHMAX
-        UME_FORCE_INLINE double hmax(SIMDVecMask<2> const & mask) const {
-            double t0 = mask.mMask[0] ? mVec[0] : std::numeric_limits<double>::lowest();
-            double t1 = (mask.mMask[1] && mVec[1] > t0) ? mVec[1] : t0;
-            return t1;
-        }
-        // IMAX
-        UME_FORCE_INLINE int32_t imax() const {
-            return mVec[0] > mVec[1] ? 0 : 1;
-        }
-        // MIMAX
-        UME_FORCE_INLINE int32_t imax(SIMDVecMask<2> const & mask) const {
-            int32_t i0 = 0xFFFFFFFF;
-            double t0 = std::numeric_limits<double>::min();
-            if(mask.mMask[0] == true) {
-                i0 = 0;
-                t0 = mVec[0];
-            }
-            if(mask.mMask[1] == true && mVec[1] > t0) {
-                i0 = 1;
-            }
-            return i0;
-        }
-        // HMIN
-        UME_FORCE_INLINE double hmin() const {
-            return mVec[0] < mVec[1] ? mVec[0] : mVec[1];
-        }
-        // MHMIN
-        UME_FORCE_INLINE double hmin(SIMDVecMask<2> const & mask) const {
-            double t0 = mask.mMask[0] ? mVec[0] : std::numeric_limits<double>::max();
-            double t1 = (mask.mMask[1] && mVec[1] < t0) ? mVec[1] : t0;
-            return t1;
-        }
-        // IMIN
-        UME_FORCE_INLINE int32_t imin() const {
-            return mVec[0] < mVec[1] ? 0 : 1;
-        }
-        // MIMIN
-        UME_FORCE_INLINE int32_t imin(SIMDVecMask<2> const & mask) const {
-            int32_t i0 = 0xFFFFFFFF;
-            double t0 = std::numeric_limits<double>::max();
-            if(mask.mMask[0] == true) {
-                i0 = 0;
-                t0 = mVec[0];
-            }
-            if(mask.mMask[1] == true && mVec[1] < t0) {
-                i0 = 1;
-            }
-            return i0;
-        }
-
-        // GATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
-            mVec[0] = baseAddr[indices[0]];
-            mVec[1] = baseAddr[indices[1]];
-            return *this;
-        }
-        // MGATHERS
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t const * indices) {
-            if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
-            if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
-            return *this;
-        }
-        // GATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, VEC_UINT_TYPE const & indices) {
-            mVec[0] = baseAddr[indices.mVec[0]];
-            mVec[1] = baseAddr[indices.mVec[1]];
-            return *this;
-        }
-        // MGATHERV
-        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, VEC_UINT_TYPE const & indices) {
-            if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
-            if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
-            return *this;
-        }
-        // SCATTERS
-        UME_FORCE_INLINE double * scatter(double * baseAddr, uint64_t * indices) const {
-            baseAddr[indices[0]] = mVec[0];
-            baseAddr[indices[1]] = mVec[1];
-            return baseAddr;
-        }
-        // MSCATTERS
-        UME_FORCE_INLINE double * scatter(SIMDVecMask<2> const & mask, double * baseAddr, uint64_t * indices) const {
-            if (mask.mMask[0] == true) baseAddr[indices[0]] = mVec[0];
-            if (mask.mMask[1] == true) baseAddr[indices[1]] = mVec[1];
-            return baseAddr;
-        }
-        // SCATTERV
-        UME_FORCE_INLINE double * scatter(double * baseAddr, VEC_UINT_TYPE const & indices) const {
-            baseAddr[indices.mVec[0]] = mVec[0];
-            baseAddr[indices.mVec[1]] = mVec[1];
-            return baseAddr;
-        }
-        // MSCATTERV
-        UME_FORCE_INLINE double * scatter(SIMDVecMask<2> const & mask, double * baseAddr, VEC_UINT_TYPE const & indices) const {
-            if (mask.mMask[0] == true) baseAddr[indices.mVec[0]] = mVec[0];
-            if (mask.mMask[1] == true) baseAddr[indices.mVec[1]] = mVec[1];
-            return baseAddr;
-        }
+//        // MINSA
+//        UME_FORCE_INLINE SIMDVec_f & mina(double b) {
+//            if(mVec[0] > b) mVec[0] = b;
+//            if(mVec[1] > b) mVec[1] = b;
+//            return *this;
+//        }
+//        // MMINSA
+//        UME_FORCE_INLINE SIMDVec_f & mina(SIMDVecMask<2> const & mask, double b) {
+//            if (mask.mMask[0] == true && mVec[0] > b) {
+//                mVec[0] = b;
+//            }
+//            if (mask.mMask[1] == true && mVec[1] > b) {
+//                mVec[1] = b;
+//            }
+//            return *this;
+//        }
+//        // HMAX
+//        UME_FORCE_INLINE double hmax() const {
+//            return mVec[0] > mVec[1] ? mVec[0] : mVec[1];
+//        }
+//        // MHMAX
+//        UME_FORCE_INLINE double hmax(SIMDVecMask<2> const & mask) const {
+//            double t0 = mask.mMask[0] ? mVec[0] : std::numeric_limits<double>::lowest();
+//            double t1 = (mask.mMask[1] && mVec[1] > t0) ? mVec[1] : t0;
+//            return t1;
+//        }
+//        // IMAX
+//        UME_FORCE_INLINE int32_t imax() const {
+//            return mVec[0] > mVec[1] ? 0 : 1;
+//        }
+//        // MIMAX
+//        UME_FORCE_INLINE int32_t imax(SIMDVecMask<2> const & mask) const {
+//            int32_t i0 = 0xFFFFFFFF;
+//            double t0 = std::numeric_limits<double>::min();
+//            if(mask.mMask[0] == true) {
+//                i0 = 0;
+//                t0 = mVec[0];
+//            }
+//            if(mask.mMask[1] == true && mVec[1] > t0) {
+//                i0 = 1;
+//            }
+//            return i0;
+//        }
+//        // HMIN
+//        UME_FORCE_INLINE double hmin() const {
+//            return mVec[0] < mVec[1] ? mVec[0] : mVec[1];
+//        }
+//        // MHMIN
+//        UME_FORCE_INLINE double hmin(SIMDVecMask<2> const & mask) const {
+//            double t0 = mask.mMask[0] ? mVec[0] : std::numeric_limits<double>::max();
+//            double t1 = (mask.mMask[1] && mVec[1] < t0) ? mVec[1] : t0;
+//            return t1;
+//        }
+//        // IMIN
+//        UME_FORCE_INLINE int32_t imin() const {
+//            return mVec[0] < mVec[1] ? 0 : 1;
+//        }
+//        // MIMIN
+//        UME_FORCE_INLINE int32_t imin(SIMDVecMask<2> const & mask) const {
+//            int32_t i0 = 0xFFFFFFFF;
+//            double t0 = std::numeric_limits<double>::max();
+//            if(mask.mMask[0] == true) {
+//                i0 = 0;
+//                t0 = mVec[0];
+//            }
+//            if(mask.mMask[1] == true && mVec[1] < t0) {
+//                i0 = 1;
+//            }
+//            return i0;
+//        }
+//
+//        // GATHERS
+//        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, uint64_t const * indices) {
+//            mVec[0] = baseAddr[indices[0]];
+//            mVec[1] = baseAddr[indices[1]];
+//            return *this;
+//        }
+//        // MGATHERS
+//        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, uint64_t const * indices) {
+//            if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
+//            if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
+//            return *this;
+//        }
+//        // GATHERV
+//        UME_FORCE_INLINE SIMDVec_f & gather(double const * baseAddr, VEC_UINT_TYPE const & indices) {
+//            mVec[0] = baseAddr[indices.mVec[0]];
+//            mVec[1] = baseAddr[indices.mVec[1]];
+//            return *this;
+//        }
+//        // MGATHERV
+//        UME_FORCE_INLINE SIMDVec_f & gather(SIMDVecMask<2> const & mask, double const * baseAddr, VEC_UINT_TYPE const & indices) {
+//            if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
+//            if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
+//            return *this;
+//        }
+//        // SCATTERS
+//        UME_FORCE_INLINE double * scatter(double * baseAddr, uint64_t * indices) const {
+//            baseAddr[indices[0]] = mVec[0];
+//            baseAddr[indices[1]] = mVec[1];
+//            return baseAddr;
+//        }
+//        // MSCATTERS
+//        UME_FORCE_INLINE double * scatter(SIMDVecMask<2> const & mask, double * baseAddr, uint64_t * indices) const {
+//            if (mask.mMask[0] == true) baseAddr[indices[0]] = mVec[0];
+//            if (mask.mMask[1] == true) baseAddr[indices[1]] = mVec[1];
+//            return baseAddr;
+//        }
+//        // SCATTERV
+//        UME_FORCE_INLINE double * scatter(double * baseAddr, VEC_UINT_TYPE const & indices) const {
+//            baseAddr[indices.mVec[0]] = mVec[0];
+//            baseAddr[indices.mVec[1]] = mVec[1];
+//            return baseAddr;
+//        }
+//        // MSCATTERV
+//        UME_FORCE_INLINE double * scatter(SIMDVecMask<2> const & mask, double * baseAddr, VEC_UINT_TYPE const & indices) const {
+//            if (mask.mMask[0] == true) baseAddr[indices.mVec[0]] = mVec[0];
+//            if (mask.mMask[1] == true) baseAddr[indices.mVec[1]] = mVec[1];
+//            return baseAddr;
+//        }
         // NEG
         UME_FORCE_INLINE SIMDVec_f neg() const {
-            return SIMDVec_f(-mVec[0], -mVec[1]);
+            float64x2_t tmp = vnegq_f64(mVec);
+            return SIMDVec_f(tmp);
         }
         UME_FORCE_INLINE SIMDVec_f operator- () const {
             return neg();
         }
         // MNEG
         UME_FORCE_INLINE SIMDVec_f neg(SIMDVecMask<2> const & mask) const {
-            double t0 = (mask.mMask[0] == true) ? -mVec[0] : mVec[0];
-            double t1 = (mask.mMask[1] == true) ? -mVec[1] : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vnegq_f64(mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // NEGA
         UME_FORCE_INLINE SIMDVec_f & nega() {
-            mVec[0] = -mVec[0];
-            mVec[1] = -mVec[1];
+            mVec = vnegq_f64(mVec);
             return *this;
         }
         // MNEGA
         UME_FORCE_INLINE SIMDVec_f & nega(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) mVec[0] = -mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = -mVec[1];
+            float64x2_t tmp = vnegq_f64(mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
         // ABS
         UME_FORCE_INLINE SIMDVec_f abs() const {
-            double t0 = (mVec[0] > 0.0f) ? mVec[0] : -mVec[0];
-            double t1 = (mVec[1] > 0.0f) ? mVec[1] : -mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vabsq_f64(mVec);
+            return SIMDVec_f(tmp);
         }
         // MABS
         UME_FORCE_INLINE SIMDVec_f abs(SIMDVecMask<2> const & mask) const {
-            double t0 = ((mask.mMask[0] == true) && (mVec[0] < 0.0f)) ? -mVec[0] : mVec[0];
-            double t1 = ((mask.mMask[1] == true) && (mVec[1] < 0.0f)) ? -mVec[1] : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vabsq_f64(mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // ABSA
         UME_FORCE_INLINE SIMDVec_f & absa() {
-            if (mVec[0] < 0.0f) mVec[0] = -mVec[0];
-            if (mVec[1] < 0.0f) mVec[1] = -mVec[1];
+            mVec = vabsq_f64(mVec);
             return *this;
         }
         // MABSA
         UME_FORCE_INLINE SIMDVec_f & absa(SIMDVecMask<2> const & mask) {
-            if ((mask.mMask[0] == true) && (mVec[0] < 0.0f)) mVec[0] = -mVec[0];
-            if ((mask.mMask[1] == true) && (mVec[1] < 0.0f)) mVec[1] = -mVec[1];
+            float64x2_t tmp = vabsq_f64(mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
 
@@ -1148,26 +1122,24 @@ namespace SIMD {
         // MSQRA
         // SQRT
         UME_FORCE_INLINE SIMDVec_f sqrt() const {
-            double t0 = std::sqrt(mVec[0]);
-            double t1 = std::sqrt(mVec[1]);
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vsqrtq_f64(mVec);
+            return SIMDVec_f(tmp);
         }
         // MSQRT
         UME_FORCE_INLINE SIMDVec_f sqrt(SIMDVecMask<2> const & mask) const {
-            double t0 = mask.mMask[0] ? std::sqrt(mVec[0]) : mVec[0];
-            double t1 = mask.mMask[1] ? std::sqrt(mVec[1]) : mVec[1];
-            return SIMDVec_f(t0, t1);
+            float64x2_t tmp = vsqrtq_f64(mVec);
+            float64x2_t tmp2 = vbslq_f64(mask.mMask, tmp, mVec);
+            return SIMDVec_f(tmp2);
         }
         // SQRTA
         UME_FORCE_INLINE SIMDVec_f & sqrta() {
-            mVec[0] = std::sqrt(mVec[0]);
-            mVec[1] = std::sqrt(mVec[1]);
+            mVec = vsqrtq_f64(mVec);
             return *this;
         }
         // MSQRTA
         UME_FORCE_INLINE SIMDVec_f & sqrta(SIMDVecMask<2> const & mask) {
-            mVec[0] = mask.mMask[0] ? std::sqrt(mVec[0]) : mVec[0];
-            mVec[1] = mask.mMask[1] ? std::sqrt(mVec[1]) : mVec[1];
+            float64x2_t tmp = vsqrtq_f64(mVec);
+            mVec = vbslq_f64(mask.mMask, tmp, mVec);
             return *this;
         }
         // POWV
@@ -1175,29 +1147,28 @@ namespace SIMD {
         // POWS
         // MPOWS
         // ROUND
-        UME_FORCE_INLINE SIMDVec_f round() const {
-            double t0 = std::roundf(mVec[0]);
-            double t1 = std::roundf(mVec[1]);
-            return SIMDVec_f(t0, t1);
-        }
-        // MROUND
-        UME_FORCE_INLINE SIMDVec_f round(SIMDVecMask<2> const & mask) const {
-            double t0 = mask.mMask[0] ? std::roundf(mVec[0]) : mVec[0];
-            double t1 = mask.mMask[1] ? std::roundf(mVec[1]) : mVec[1];
-            return SIMDVec_f(t0, t1);
-        }
-        // TRUNC
-        UME_FORCE_INLINE SIMDVec_i<int64_t, 2> trunc() const {
-            int64_t t0 = (int64_t)mVec[0];
-            int64_t t1 = (int64_t)mVec[1];
-            return SIMDVec_i<int64_t, 2>(t0, t1);
-        }
-        // MTRUNC
-        UME_FORCE_INLINE SIMDVec_i<int64_t, 2> trunc(SIMDVecMask<2> const & mask) const {
-            int64_t t0 = mask.mMask[0] ? (int64_t)mVec[0] : 0;
-            int64_t t1 = mask.mMask[1] ? (int64_t)mVec[1] : 0;
-            return SIMDVec_i<int64_t, 2>(t0, t1);
-        }
+//        UME_FORCE_INLINE SIMDVec_f round() const {
+//            float64x2_t tmp = vrndnq_f64(mVec); // not available wit h gcc
+//            return SIMDVec_f(tmp);
+//        }
+//        // MROUND
+//        UME_FORCE_INLINE SIMDVec_f round(SIMDVecMask<2> const & mask) const {
+//            double t0 = mask.mMask[0] ? std::roundf(mVec[0]) : mVec[0];
+//            double t1 = mask.mMask[1] ? std::roundf(mVec[1]) : mVec[1];
+//            return SIMDVec_f(t0, t1);
+//        }
+//        // TRUNC
+//        UME_FORCE_INLINE SIMDVec_i<int64_t, 2> trunc() const {
+//            int64_t t0 = (int64_t)mVec[0];
+//            int64_t t1 = (int64_t)mVec[1];
+//            return SIMDVec_i<int64_t, 2>(t0, t1);
+//        }
+//        // MTRUNC
+//        UME_FORCE_INLINE SIMDVec_i<int64_t, 2> trunc(SIMDVecMask<2> const & mask) const {
+//            int64_t t0 = mask.mMask[0] ? (int64_t)mVec[0] : 0;
+//            int64_t t1 = mask.mMask[1] ? (int64_t)mVec[1] : 0;
+//            return SIMDVec_i<int64_t, 2>(t0, t1);
+//        }
         // FLOOR
         // MFLOOR
         // CEIL
@@ -1259,35 +1230,35 @@ namespace SIMD {
         // CTAN
         // MCTAN
 
-        // PACK
-        UME_FORCE_INLINE SIMDVec_f & pack(HALF_LEN_VEC_TYPE const & a, HALF_LEN_VEC_TYPE const & b) {
-            mVec[0] = a[0];
-            mVec[1] = b[0];
-            return *this;
-        }
-        // PACKLO
-        UME_FORCE_INLINE SIMDVec_f & packlo(SIMDVec_f<double, 1> const & a) {
-            mVec[0] = a[0];
-            return *this;
-        }
-        // PACKHI
-        UME_FORCE_INLINE SIMDVec_f & packhi(SIMDVec_f<double, 1> const & b) {
-            mVec[1] = b[0];
-            return *this;
-        }
-        // UNPACK
-        UME_FORCE_INLINE void unpack(SIMDVec_f<double, 1> & a, SIMDVec_f<double, 1> & b) {
-            a.insert(0, mVec[0]);
-            b.insert(0, mVec[1]);
-        }
-        // UNPACKLO
-        UME_FORCE_INLINE SIMDVec_f<double, 1> unpacklo() const {
-            return SIMDVec_f<double, 1>(mVec[0]);
-        }
-        // UNPACKHI
-        UME_FORCE_INLINE SIMDVec_f<double, 1> unpackhi() const {
-            return SIMDVec_f<double, 1>(mVec[1]);
-        }
+//        // PACK
+//        UME_FORCE_INLINE SIMDVec_f & pack(HALF_LEN_VEC_TYPE const & a, HALF_LEN_VEC_TYPE const & b) {
+//            mVec[0] = a[0];
+//            mVec[1] = b[0];
+//            return *this;
+//        }
+//        // PACKLO
+//        UME_FORCE_INLINE SIMDVec_f & packlo(SIMDVec_f<double, 1> const & a) {
+//            mVec[0] = a[0];
+//            return *this;
+//        }
+//        // PACKHI
+//        UME_FORCE_INLINE SIMDVec_f & packhi(SIMDVec_f<double, 1> const & b) {
+//            mVec[1] = b[0];
+//            return *this;
+//        }
+//        // UNPACK
+//        UME_FORCE_INLINE void unpack(SIMDVec_f<double, 1> & a, SIMDVec_f<double, 1> & b) {
+//            a.insert(0, mVec[0]);
+//            b.insert(0, mVec[1]);
+//        }
+//        // UNPACKLO
+//        UME_FORCE_INLINE SIMDVec_f<double, 1> unpacklo() const {
+//            return SIMDVec_f<double, 1>(mVec[0]);
+//        }
+//        // UNPACKHI
+//        UME_FORCE_INLINE SIMDVec_f<double, 1> unpackhi() const {
+//            return SIMDVec_f<double, 1>(mVec[1]);
+//        }
 
         // PROMOTE
         // DEGRADE
@@ -1301,5 +1272,7 @@ namespace SIMD {
 
 }
 }
+
+#undef GET_CONST_INT
 
 #endif

--- a/plugins/arm/int/UMESimdVecInt32_2.h
+++ b/plugins/arm/int/UMESimdVecInt32_2.h
@@ -135,8 +135,8 @@ namespace SIMD {
         }
         // MASSIGNV
         UME_FORCE_INLINE SIMDVec_i & assign(SIMDVecMask<2> const & mask, SIMDVec_i const & b) {
-            if (mask.mMask[0] == true) mVec[0] = b.mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = b.mVec[1];
+            if (mask.mMask[0]) mVec[0] = b.mVec[0];
+            if (mask.mMask[1]) mVec[1] = b.mVec[1];
             return *this;
         }
         // ASSIGNS
@@ -150,8 +150,8 @@ namespace SIMD {
         }
         // MASSIGNS
         UME_FORCE_INLINE SIMDVec_i & assign(SIMDVecMask<2> const & mask, int32_t b) {
-            if (mask.mMask[0] == true) mVec[0] = b;
-            if (mask.mMask[1] == true) mVec[1] = b;
+            if (mask.mMask[0]) mVec[0] = b;
+            if (mask.mMask[1]) mVec[1] = b;
             return *this;
         }
 
@@ -167,8 +167,8 @@ namespace SIMD {
         }
         // MLOAD
         UME_FORCE_INLINE SIMDVec_i & load(SIMDVecMask<2> const & mask, int32_t const *p) {
-            if (mask.mMask[0] == true) mVec[0] = p[0];
-            if (mask.mMask[1] == true) mVec[1] = p[1];
+            if (mask.mMask[0]) mVec[0] = p[0];
+            if (mask.mMask[1]) mVec[1] = p[1];
             return *this;
         }
         // LOADA
@@ -179,8 +179,8 @@ namespace SIMD {
         }
         // MLOADA
         UME_FORCE_INLINE SIMDVec_i & loada(SIMDVecMask<2> const & mask, int32_t const *p) {
-            if (mask.mMask[0] == true) mVec[0] = p[0];
-            if (mask.mMask[1] == true) mVec[1] = p[1];
+            if (mask.mMask[0]) mVec[0] = p[0];
+            if (mask.mMask[1]) mVec[1] = p[1];
             return *this;
         }
         // STORE
@@ -191,8 +191,8 @@ namespace SIMD {
         }
         // MSTORE
         UME_FORCE_INLINE int32_t* store(SIMDVecMask<2> const & mask, int32_t* p) const {
-            if (mask.mMask[0] == true) p[0] = mVec[0];
-            if (mask.mMask[1] == true) p[1] = mVec[1];
+            if (mask.mMask[0]) p[0] = mVec[0];
+            if (mask.mMask[1]) p[1] = mVec[1];
             return p;
         }
         // STOREA
@@ -203,8 +203,8 @@ namespace SIMD {
         }
         // MSTOREA
         UME_FORCE_INLINE int32_t* storea(SIMDVecMask<2> const & mask, int32_t* p) const {
-            if (mask.mMask[0] == true) p[0] = mVec[0];
-            if (mask.mMask[1] == true) p[1] = mVec[1];
+            if (mask.mMask[0]) p[0] = mVec[0];
+            if (mask.mMask[1]) p[1] = mVec[1];
             return p;
         }
 
@@ -465,8 +465,8 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_i postinc(SIMDVecMask<2> const & mask) {
             int32_t t0 = mVec[0];
             int32_t t1 = mVec[1];
-            if(mask.mMask[0] == true) mVec[0]++;
-            if(mask.mMask[1] == true) mVec[1]++;
+            if(mask.mMask[0]) mVec[0]++;
+            if(mask.mMask[1]) mVec[1]++;
             return SIMDVec_i(t0, t1);
         }
         // PREFINC
@@ -480,8 +480,8 @@ namespace SIMD {
         }
         // MPREFINC
         UME_FORCE_INLINE SIMDVec_i & prefinc(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) mVec[0]++;
-            if (mask.mMask[1] == true) mVec[1]++;
+            if (mask.mMask[0]) mVec[0]++;
+            if (mask.mMask[1]) mVec[1]++;
             return *this;
         }
         // SUBV
@@ -553,10 +553,10 @@ namespace SIMD {
         // MSSUBV
         UME_FORCE_INLINE SIMDVec_i ssub(SIMDVecMask<2> const & mask, SIMDVec_i const & b) const {
             int32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = (mVec[0] < b.mVec[0]) ? 0 : mVec[0] - b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = (mVec[1] < b.mVec[1]) ? 0 : mVec[1] - b.mVec[1];
             }
             return SIMDVec_i(t0, t1);
@@ -570,10 +570,10 @@ namespace SIMD {
         // MSSUBS
         UME_FORCE_INLINE SIMDVec_i ssub(SIMDVecMask<2> const & mask, int32_t b) const {
             int32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = (mVec[0] < b) ? 0 : mVec[0] - b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = (mVec[1] < b) ? 0 : mVec[1] - b;
             }
             return SIMDVec_i(t0, t1);
@@ -586,10 +586,10 @@ namespace SIMD {
         }
         // MSSUBVA
         UME_FORCE_INLINE SIMDVec_i & ssuba(SIMDVecMask<2> const & mask, SIMDVec_i const & b) {
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 mVec[0] = (mVec[0] < b.mVec[0]) ? 0 : mVec[0] - b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 mVec[0] = (mVec[0] < b.mVec[0]) ? 0 : mVec[0] - b.mVec[0];
             }
             return *this;
@@ -602,10 +602,10 @@ namespace SIMD {
         }
         // MSSUBSA
         UME_FORCE_INLINE SIMDVec_i & ssuba(SIMDVecMask<2> const & mask, int32_t b)  {
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 mVec[0] = (mVec[0] < b) ? 0 : mVec[0] - b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 mVec[1] = (mVec[1] < b) ? 0 : mVec[1] - b;
             }
             return *this;
@@ -671,8 +671,8 @@ namespace SIMD {
         // MPOSTDEC
         UME_FORCE_INLINE SIMDVec_i postdec(SIMDVecMask<2> const & mask) {
             int32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) mVec[0]--;
-            if (mask.mMask[1] == true) mVec[1]--;
+            if (mask.mMask[0]) mVec[0]--;
+            if (mask.mMask[1]) mVec[1]--;
             return SIMDVec_i(t0, t1);
         }
         // PREFDEC
@@ -686,8 +686,8 @@ namespace SIMD {
         }
         // MPREFDEC
         UME_FORCE_INLINE SIMDVec_i & prefdec(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) mVec[0]--;
-            if (mask.mMask[1] == true) mVec[1]--;
+            if (mask.mMask[0]) mVec[0]--;
+            if (mask.mMask[1]) mVec[1]--;
             return *this;
         }
         // MULV
@@ -1042,10 +1042,10 @@ namespace SIMD {
         // MMAXV
         UME_FORCE_INLINE SIMDVec_i max(SIMDVecMask<2> const & mask, SIMDVec_i const & b) const {
             int32_t t0 = mVec[0], t1  = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = mVec[0] > b.mVec[0] ? mVec[0] : b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t0 = mVec[1] > b.mVec[1] ? mVec[1] : b.mVec[1];
             }
             return SIMDVec_i(t0, t1);
@@ -1059,10 +1059,10 @@ namespace SIMD {
         // MMAXS
         UME_FORCE_INLINE SIMDVec_i max(SIMDVecMask<2> const & mask, int32_t b) const {
             int32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = mVec[0] > b ? mVec[0] : b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = mVec[1] > b ? mVec[1] : b;
             }
             return SIMDVec_i(t0, t1);
@@ -1075,10 +1075,10 @@ namespace SIMD {
         }
         // MMAXVA
         UME_FORCE_INLINE SIMDVec_i & maxa(SIMDVecMask<2> const & mask, SIMDVec_i const & b) {
-            if (mask.mMask[0] == true && mVec[0] < b.mVec[0]) {
+            if (mask.mMask[0] && mVec[0] < b.mVec[0]) {
                 mVec[0] = b.mVec[0];
             }
-            if (mask.mMask[1] == true && mVec[1] < b.mVec[1]) {
+            if (mask.mMask[1] && mVec[1] < b.mVec[1]) {
                 mVec[1] = b.mVec[1];
             }
             return *this;
@@ -1091,10 +1091,10 @@ namespace SIMD {
         }
         // MMAXSA
         UME_FORCE_INLINE SIMDVec_i & maxa(SIMDVecMask<2> const & mask, int32_t b) {
-            if (mask.mMask[0] == true && mVec[0] < b) {
+            if (mask.mMask[0] && mVec[0] < b) {
                 mVec[0] = b;
             }
-            if (mask.mMask[1] == true && mVec[1] < b) {
+            if (mask.mMask[1] && mVec[1] < b) {
                 mVec[1] = b;
             }
             return *this;
@@ -1108,10 +1108,10 @@ namespace SIMD {
         // MMINV
         UME_FORCE_INLINE SIMDVec_i min(SIMDVecMask<2> const & mask, SIMDVec_i const & b) const {
             int32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = mVec[0] < b.mVec[0] ? mVec[0] : b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = mVec[1] < b.mVec[1] ? mVec[1] : b.mVec[1];
             }
             return SIMDVec_i(t0, t1);
@@ -1125,10 +1125,10 @@ namespace SIMD {
         // MMINS
         UME_FORCE_INLINE SIMDVec_i min(SIMDVecMask<2> const & mask, int32_t b) const {
             int32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = mVec[0] < b ? mVec[0] : b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = mVec[1] < b ? mVec[1] : b;
             }
             return SIMDVec_i(t0, t1);
@@ -1141,10 +1141,10 @@ namespace SIMD {
         }
         // MMINVA
         UME_FORCE_INLINE SIMDVec_i & mina(SIMDVecMask<2> const & mask, SIMDVec_i const & b) {
-            if (mask.mMask[0] == true && mVec[0] > b.mVec[0]) {
+            if (mask.mMask[0] && mVec[0] > b.mVec[0]) {
                 mVec[0] = b.mVec[0];
             }
-            if (mask.mMask[1] == true && mVec[1] > b.mVec[1]) {
+            if (mask.mMask[1] && mVec[1] > b.mVec[1]) {
                 mVec[1] = b.mVec[1];
             }
             return *this;
@@ -1157,10 +1157,10 @@ namespace SIMD {
         }
         // MMINSA
         UME_FORCE_INLINE SIMDVec_i & mina(SIMDVecMask<2> const & mask, int32_t b) {
-            if (mask.mMask[0] == true && mVec[0] > b) {
+            if (mask.mMask[0] && mVec[0] > b) {
                 mVec[0] = b;
             }
-            if (mask.mMask[1] == true && mVec[1] > b) {
+            if (mask.mMask[1] && mVec[1] > b) {
                 mVec[1] = b;
             }
             return *this;
@@ -1183,11 +1183,11 @@ namespace SIMD {
         UME_FORCE_INLINE int32_t imax(SIMDVecMask<2> const & mask) const {
             int32_t i0 = 0xFFFFFFFF;
             int32_t t0 = std::numeric_limits<int32_t>::min();
-            if(mask.mMask[0] == true) {
+            if(mask.mMask[0]) {
                 i0 = 0;
                 t0 = mVec[0];
             }
-            if(mask.mMask[1] == true && mVec[1] > t0) {
+            if(mask.mMask[1] && mVec[1] > t0) {
                 i0 = 1;
             }
             return i0;
@@ -1210,11 +1210,11 @@ namespace SIMD {
         UME_FORCE_INLINE int32_t imin(SIMDVecMask<2> const & mask) const {
             int32_t i0 = 0xFFFFFFFF;
             int32_t t0 = std::numeric_limits<int32_t>::max();
-            if(mask.mMask[0] == true) {
+            if(mask.mMask[0]) {
                 i0 = 0;
                 t0 = mVec[0];
             }
-            if(mask.mMask[1] == true && mVec[1] < t0) {
+            if(mask.mMask[1] && mVec[1] < t0) {
                 i0 = 1;
             }
             return i0;
@@ -1494,8 +1494,8 @@ namespace SIMD {
         }
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_i & gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, uint32_t const * indices) {
-            if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
-            if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
+            if (mask.mMask[0]) mVec[0] = baseAddr[indices[0]];
+            if (mask.mMask[1]) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
@@ -1506,8 +1506,8 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_i gather(SIMDVecMask<2> const & mask, int32_t const * baseAddr, SIMDVec_u<uint32_t, 2> const & indices) {
-            if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
-            if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
+            if (mask.mMask[0]) mVec[0] = baseAddr[indices.mVec[0]];
+            if (mask.mMask[1]) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // SCATTERS
@@ -1518,8 +1518,8 @@ namespace SIMD {
         }
         // MSCATTERS
         UME_FORCE_INLINE int32_t*  scatter(SIMDVecMask<2> const & mask, int32_t* baseAddr, uint32_t* indices) const {
-            if (mask.mMask[0] == true) baseAddr[indices[0]] = mVec[0];
-            if (mask.mMask[1] == true) baseAddr[indices[1]] = mVec[1];
+            if (mask.mMask[0]) baseAddr[indices[0]] = mVec[0];
+            if (mask.mMask[1]) baseAddr[indices[1]] = mVec[1];
             return baseAddr;
         }
         // SCATTERV
@@ -1530,8 +1530,8 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE int32_t*  scatter(SIMDVecMask<2> const & mask, int32_t* baseAddr, SIMDVec_u<uint32_t, 2> const & indices) const {
-            if (mask.mMask[0] == true) baseAddr[indices.mVec[0]] = mVec[0];
-            if (mask.mMask[1] == true) baseAddr[indices.mVec[1]] = mVec[1];
+            if (mask.mMask[0]) baseAddr[indices.mVec[0]] = mVec[0];
+            if (mask.mMask[1]) baseAddr[indices.mVec[1]] = mVec[1];
             return baseAddr;
         }
 
@@ -1657,8 +1657,8 @@ namespace SIMD {
         }
         // MNEG
         UME_FORCE_INLINE SIMDVec_i neg(SIMDVecMask<2> const & mask) const {
-            int32_t t0 = (mask.mMask[0] == true) ? -mVec[0] : mVec[0];
-            int32_t t1 = (mask.mMask[1] == true) ? -mVec[1] : mVec[1];
+            int32_t t0 = (mask.mMask[0]) ? -mVec[0] : mVec[0];
+            int32_t t1 = (mask.mMask[1]) ? -mVec[1] : mVec[1];
             return SIMDVec_i(t0, t1);
         }
         // NEGA
@@ -1669,8 +1669,8 @@ namespace SIMD {
         }
         // MNEGA
         UME_FORCE_INLINE SIMDVec_i & nega(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) mVec[0] = -mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = -mVec[1];
+            if (mask.mMask[0]) mVec[0] = -mVec[0];
+            if (mask.mMask[1]) mVec[1] = -mVec[1];
             return *this;
         }
         // ABS
@@ -1681,8 +1681,8 @@ namespace SIMD {
         }
         // MABS
         UME_FORCE_INLINE SIMDVec_i abs(SIMDVecMask<2> const & mask) const {
-            int32_t t0 = ((mask.mMask[0] == true) && (mVec[0] < 0)) ? -mVec[0] : mVec[0];
-            int32_t t1 = ((mask.mMask[1] == true) && (mVec[1] < 0)) ? -mVec[1] : mVec[1];
+            int32_t t0 = ((mask.mMask[0]) && (mVec[0] < 0)) ? -mVec[0] : mVec[0];
+            int32_t t1 = ((mask.mMask[1]) && (mVec[1] < 0)) ? -mVec[1] : mVec[1];
             return SIMDVec_i(t0, t1);
         }
         // ABSA
@@ -1693,8 +1693,8 @@ namespace SIMD {
         }
         // MABSA
         UME_FORCE_INLINE SIMDVec_i & absa(SIMDVecMask<2> const & mask) {
-            if ((mask.mMask[0] == true) && (mVec[0] < 0)) mVec[0] = -mVec[0];
-            if ((mask.mMask[1] == true) && (mVec[1] < 0)) mVec[1] = -mVec[1];
+            if ((mask.mMask[0]) && (mVec[0] < 0)) mVec[0] = -mVec[0];
+            if ((mask.mMask[1]) && (mVec[1] < 0)) mVec[1] = -mVec[1];
             return *this;
         }
 

--- a/plugins/arm/mask/UMESimdMask2.h
+++ b/plugins/arm/mask/UMESimdMask2.h
@@ -45,8 +45,8 @@ namespace SIMD {
         uint32_t,
         2>
     {
-        static uint64_t TRUE_VAL() { return 0xFFFFFFFFFFFFFFFF; };
-        static uint64_t FALSE_VAL() { return 0x0000000000000000; };
+        static UME_FORCE_INLINE uint64_t TRUE_VAL() { return 0xFFFFFFFFFFFFFFFF; };
+        static UME_FORCE_INLINE uint64_t FALSE_VAL() { return 0x0000000000000000; };
 
         friend class SIMDVec_u<uint32_t, 2>;
         friend class SIMDVec_u<uint64_t, 2>;

--- a/plugins/arm/mask/UMESimdMask2.h
+++ b/plugins/arm/mask/UMESimdMask2.h
@@ -33,6 +33,8 @@
 
 #include "UMESimdMaskPrototype.h"
 
+#define GET_CONST_INT(x) x == 0 ? 0 : x == 1
+
 namespace UME {
 namespace SIMD {
 
@@ -43,6 +45,9 @@ namespace SIMD {
         uint32_t,
         2>
     {
+        static uint64_t TRUE_VAL() { return 0xFFFFFFFFFFFFFFFF; };
+        static uint64_t FALSE_VAL() { return 0x0000000000000000; };
+
         friend class SIMDVec_u<uint32_t, 2>;
         friend class SIMDVec_u<uint64_t, 2>;
         friend class SIMDVec_i<int32_t, 2>;
@@ -50,7 +55,12 @@ namespace SIMD {
         friend class SIMDVec_f<float, 2>;
         friend class SIMDVec_f<double, 2>;
     private:
-        bool mMask[2];
+        uint64x2_t mMask;
+
+        UME_FORCE_INLINE explicit SIMDVecMask(uint64x2_t m) {
+            mMask = m;
+        }
+
 
     public:
         UME_FORCE_INLINE SIMDVecMask() {}
@@ -58,53 +68,64 @@ namespace SIMD {
         // Regardless of the mask representation, the interface should only allow initialization using 
         // standard bool or using equivalent mask
         UME_FORCE_INLINE SIMDVecMask(bool m) {
-            mMask[0] = m;
-            mMask[1] = m;
+            mMask = vdupq_n_u64(m ? TRUE_VAL() : FALSE_VAL());
         }
 
         // LOAD-CONSTR - Construct by loading from memory
         UME_FORCE_INLINE explicit SIMDVecMask(bool const * p) {
-            mMask[0] = p[0];
-            mMask[1] = p[1];
+            alignas(16) uint64_t raw[2] = {p[0] ? TRUE_VAL() : FALSE_VAL(),
+                                           p[1] ? TRUE_VAL() : FALSE_VAL()};
+
+            mMask = vld1q_u64(raw);
         }
 
         UME_FORCE_INLINE SIMDVecMask(bool m0, bool m1) {
-            mMask[0] = m0;
-            mMask[1] = m1;
+            alignas(16) uint64_t raw[2] = {m0 ? TRUE_VAL() : FALSE_VAL(),
+                                           m1 ? TRUE_VAL() : FALSE_VAL()};
+
+            mMask = vld1q_u64(raw);
         }
 
         UME_FORCE_INLINE SIMDVecMask(SIMDVecMask const & mask) {
-            mMask[0] = mask.mMask[0];
-            mMask[1] = mask.mMask[1];
+            mMask = mask.mMask;
         }
 
         UME_FORCE_INLINE bool extract(uint32_t index) const {
-            return mMask[index & 1];
+            if ((index & 1) == 0) {
+                return vgetq_lane_u64(mMask, 0) == TRUE_VAL();
+            }
+            return vgetq_lane_u64(mMask, 1) == TRUE_VAL();
         }
 
         // A non-modifying element-wise access operator
         UME_FORCE_INLINE bool operator[] (uint32_t index) const {
-            return mMask[index & 1];
+            return extract(index);
         }
 
         // Element-wise modification operator
         UME_FORCE_INLINE void insert(uint32_t index, bool x) {
-            mMask[index & 1] = x;
+            if ((index & 1) == 0) {
+                mMask = vsetq_lane_u64(x ? TRUE_VAL() : FALSE_VAL(), mMask, 0);
+            } else {
+                mMask = vsetq_lane_u64(x ? TRUE_VAL() : FALSE_VAL(), mMask, 1);
+            }
         }
 
         UME_FORCE_INLINE SIMDVecMask & operator= (SIMDVecMask const & mask) {
-            mMask[0] = mask.mMask[0];
-            mMask[1] = mask.mMask[1];
+            mMask = mask.mMask;
             return *this;
         }
 
         // HLOR
         UME_FORCE_INLINE bool hlor() const {
-            return mMask[0] || mMask[1];
+            //return vminvq_u32(vreinterpretq_u32_u64(mMask)) != 0;
+            return extract(0) || extract(1);
         }
     };
 
 }
 }
+
+#undef GET_CONST_INT
 
 #endif

--- a/plugins/arm/uint/UMESimdVecUint32_2.h
+++ b/plugins/arm/uint/UMESimdVecUint32_2.h
@@ -128,8 +128,8 @@ namespace SIMD {
         }
         // MASSIGNV
         UME_FORCE_INLINE SIMDVec_u & assign(SIMDVecMask<2> const & mask, SIMDVec_u const & src) {
-            if (mask.mMask[0] == true) mVec[0] = src.mVec[0];
-            if (mask.mMask[1] == true) mVec[1] = src.mVec[1];
+            if (mask.mMask[0]) mVec[0] = src.mVec[0];
+            if (mask.mMask[1]) mVec[1] = src.mVec[1];
             return *this;
         }
         // ASSIGNS
@@ -143,8 +143,8 @@ namespace SIMD {
         }
         // MASSIGNS
         UME_FORCE_INLINE SIMDVec_u & assign(SIMDVecMask<2> const & mask, uint32_t b) {
-            if (mask.mMask[0] == true) mVec[0] = b;
-            if (mask.mMask[1] == true) mVec[1] = b;
+            if (mask.mMask[0]) mVec[0] = b;
+            if (mask.mMask[1]) mVec[1] = b;
             return *this;
         }
 
@@ -160,8 +160,8 @@ namespace SIMD {
         }
         // MLOAD
         UME_FORCE_INLINE SIMDVec_u & load(SIMDVecMask<2> const & mask, uint32_t const *p) {
-            if (mask.mMask[0] == true) mVec[0] = p[0];
-            if (mask.mMask[1] == true) mVec[1] = p[1];
+            if (mask.mMask[0]) mVec[0] = p[0];
+            if (mask.mMask[1]) mVec[1] = p[1];
             return *this;
         }
         // LOADA
@@ -172,8 +172,8 @@ namespace SIMD {
         }
         // MLOADA
         UME_FORCE_INLINE SIMDVec_u & loada(SIMDVecMask<2> const & mask, uint32_t const *p) {
-            if (mask.mMask[0] == true) mVec[0] = p[0];
-            if (mask.mMask[1] == true) mVec[1] = p[1];
+            if (mask.mMask[0]) mVec[0] = p[0];
+            if (mask.mMask[1]) mVec[1] = p[1];
             return *this;
         }
         // STORE
@@ -184,8 +184,8 @@ namespace SIMD {
         }
         // MSTORE
         UME_FORCE_INLINE uint32_t* store(SIMDVecMask<2> const & mask, uint32_t* p) const {
-            if (mask.mMask[0] == true) p[0] = mVec[0];
-            if (mask.mMask[1] == true) p[1] = mVec[1];
+            if (mask.mMask[0]) p[0] = mVec[0];
+            if (mask.mMask[1]) p[1] = mVec[1];
             return p;
         }
         // STOREA
@@ -196,8 +196,8 @@ namespace SIMD {
         }
         // MSTOREA
         UME_FORCE_INLINE uint32_t* storea(SIMDVecMask<2> const & mask, uint32_t* p) const {
-            if (mask.mMask[0] == true) p[0] = mVec[0];
-            if (mask.mMask[1] == true) p[1] = mVec[1];
+            if (mask.mMask[0]) p[0] = mVec[0];
+            if (mask.mMask[1]) p[1] = mVec[1];
             return p;
         }
 
@@ -287,10 +287,10 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_u sadd(SIMDVecMask<2> const & mask, SIMDVec_u const & b) const {
             const uint32_t MAX_VAL = std::numeric_limits<uint32_t>::max();
             uint32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = (mVec[0] > MAX_VAL - b.mVec[0]) ? MAX_VAL : mVec[0] + b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = (mVec[1] > MAX_VAL - b.mVec[1]) ? MAX_VAL : mVec[1] + b.mVec[1];
             }
             return SIMDVec_u(t0, t1);
@@ -306,10 +306,10 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_u sadd(SIMDVecMask<2> const & mask, uint32_t b) const {
             const uint32_t MAX_VAL = std::numeric_limits<uint32_t>::max();
             uint32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = (mVec[0] > MAX_VAL - b) ? MAX_VAL : mVec[0] + b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = (mVec[1] > MAX_VAL - b) ? MAX_VAL : mVec[1] + b;
             }
             return SIMDVec_u(t0, t1);
@@ -324,10 +324,10 @@ namespace SIMD {
         // MSADDVA
         UME_FORCE_INLINE SIMDVec_u & sadda(SIMDVecMask<2> const & mask, SIMDVec_u const & b) {
             const uint32_t MAX_VAL = std::numeric_limits<uint32_t>::max();
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 mVec[0] = (mVec[0] > MAX_VAL - b.mVec[0]) ? MAX_VAL : mVec[0] + b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 mVec[1] = (mVec[1] > MAX_VAL - b.mVec[1]) ? MAX_VAL : mVec[1] + b.mVec[1];
             }
             return *this;
@@ -342,10 +342,10 @@ namespace SIMD {
         // MSADDSA
         UME_FORCE_INLINE SIMDVec_u & sadda(SIMDVecMask<2> const & mask, uint32_t b) {
             const uint32_t MAX_VAL = std::numeric_limits<uint32_t>::max();
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 mVec[0] = (mVec[0] > MAX_VAL - b) ? MAX_VAL : mVec[0] + b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 mVec[1] = (mVec[1] > MAX_VAL - b) ? MAX_VAL : mVec[1] + b;
             }
             return *this;
@@ -365,8 +365,8 @@ namespace SIMD {
         UME_FORCE_INLINE SIMDVec_u postinc(SIMDVecMask<2> const & mask) {
             uint32_t t0 = mVec[0];
             uint32_t t1 = mVec[1];
-            if(mask.mMask[0] == true) mVec[0]++;
-            if(mask.mMask[1] == true) mVec[1]++;
+            if(mask.mMask[0]) mVec[0]++;
+            if(mask.mMask[1]) mVec[1]++;
             return SIMDVec_u(t0, t1);
         }
         // PREFINC
@@ -380,8 +380,8 @@ namespace SIMD {
         }
         // MPREFINC
         UME_FORCE_INLINE SIMDVec_u & prefinc(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) mVec[0]++;
-            if (mask.mMask[1] == true) mVec[1]++;
+            if (mask.mMask[0]) mVec[0]++;
+            if (mask.mMask[1]) mVec[1]++;
             return *this;
         }
         // SUBV
@@ -453,10 +453,10 @@ namespace SIMD {
         // MSSUBV
         UME_FORCE_INLINE SIMDVec_u ssub(SIMDVecMask<2> const & mask, SIMDVec_u const & b) const {
             uint32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = (mVec[0] < b.mVec[0]) ? 0 : mVec[0] - b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = (mVec[1] < b.mVec[1]) ? 0 : mVec[1] - b.mVec[1];
             }
             return SIMDVec_u(t0, t1);
@@ -470,10 +470,10 @@ namespace SIMD {
         // MSSUBS
         UME_FORCE_INLINE SIMDVec_u ssub(SIMDVecMask<2> const & mask, uint32_t b) const {
             uint32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = (mVec[0] < b) ? 0 : mVec[0] - b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = (mVec[1] < b) ? 0 : mVec[1] - b;
             }
             return SIMDVec_u(t0, t1);
@@ -486,10 +486,10 @@ namespace SIMD {
         }
         // MSSUBVA
         UME_FORCE_INLINE SIMDVec_u & ssuba(SIMDVecMask<2> const & mask, SIMDVec_u const & b) {
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 mVec[0] = (mVec[0] < b.mVec[0]) ? 0 : mVec[0] - b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 mVec[0] = (mVec[0] < b.mVec[0]) ? 0 : mVec[0] - b.mVec[0];
             }
             return *this;
@@ -502,10 +502,10 @@ namespace SIMD {
         }
         // MSSUBSA
         UME_FORCE_INLINE SIMDVec_u & ssuba(SIMDVecMask<2> const & mask, uint32_t b)  {
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 mVec[0] = (mVec[0] < b) ? 0 : mVec[0] - b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 mVec[1] = (mVec[1] < b) ? 0 : mVec[1] - b;
             }
             return *this;
@@ -571,8 +571,8 @@ namespace SIMD {
         // MPOSTDEC
         UME_FORCE_INLINE SIMDVec_u postdec(SIMDVecMask<2> const & mask) {
             uint32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) mVec[0]--;
-            if (mask.mMask[1] == true) mVec[1]--;
+            if (mask.mMask[0]) mVec[0]--;
+            if (mask.mMask[1]) mVec[1]--;
             return SIMDVec_u(t0, t1);
         }
         // PREFDEC
@@ -586,8 +586,8 @@ namespace SIMD {
         }
         // MPREFDEC
         UME_FORCE_INLINE SIMDVec_u & prefdec(SIMDVecMask<2> const & mask) {
-            if (mask.mMask[0] == true) mVec[0]--;
-            if (mask.mMask[1] == true) mVec[1]--;
+            if (mask.mMask[0]) mVec[0]--;
+            if (mask.mMask[1]) mVec[1]--;
             return *this;
         }
         // MULV
@@ -941,10 +941,10 @@ namespace SIMD {
         // MMAXV
         UME_FORCE_INLINE SIMDVec_u max(SIMDVecMask<2> const & mask, SIMDVec_u const & b) const {
             uint32_t t0 = mVec[0], t1  = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = mVec[0] > b.mVec[0] ? mVec[0] : b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t0 = mVec[1] > b.mVec[1] ? mVec[1] : b.mVec[1];
             }
             return SIMDVec_u(t0, t1);
@@ -958,10 +958,10 @@ namespace SIMD {
         // MMAXS
         UME_FORCE_INLINE SIMDVec_u max(SIMDVecMask<2> const & mask, uint32_t b) const {
             uint32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = mVec[0] > b ? mVec[0] : b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = mVec[1] > b ? mVec[1] : b;
             }
             return SIMDVec_u(t0, t1);
@@ -1007,10 +1007,10 @@ namespace SIMD {
         // MMINV
         UME_FORCE_INLINE SIMDVec_u min(SIMDVecMask<2> const & mask, SIMDVec_u const & b) const {
             uint32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = mVec[0] < b.mVec[0] ? mVec[0] : b.mVec[0];
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = mVec[1] < b.mVec[1] ? mVec[1] : b.mVec[1];
             }
             return SIMDVec_u(t0, t1);
@@ -1024,10 +1024,10 @@ namespace SIMD {
         // MMINS
         UME_FORCE_INLINE SIMDVec_u min(SIMDVecMask<2> const & mask, uint32_t b) const {
             uint32_t t0 = mVec[0], t1 = mVec[1];
-            if (mask.mMask[0] == true) {
+            if (mask.mMask[0]) {
                 t0 = mVec[0] < b ? mVec[0] : b;
             }
-            if (mask.mMask[1] == true) {
+            if (mask.mMask[1]) {
                 t1 = mVec[1] < b ? mVec[1] : b;
             }
             return SIMDVec_u(t0, t1);
@@ -1082,11 +1082,11 @@ namespace SIMD {
         UME_FORCE_INLINE uint32_t imax(SIMDVecMask<2> const & mask) const {
             uint32_t i0 = 0xFFFFFFFF;
             uint32_t t0 = std::numeric_limits<uint32_t>::min();
-            if(mask.mMask[0] == true) {
+            if(mask.mMask[0]) {
                 i0 = 0;
                 t0 = mVec[0];
             }
-            if(mask.mMask[1] == true && mVec[1] > t0) {
+            if(mask.mMask[1] && mVec[1] > t0) {
                 i0 = 1;
             }
             return i0;
@@ -1109,11 +1109,11 @@ namespace SIMD {
         UME_FORCE_INLINE uint32_t imin(SIMDVecMask<2> const & mask) const {
             uint32_t i0 = 0xFFFFFFFF;
             uint32_t t0 = std::numeric_limits<uint32_t>::max();
-            if(mask.mMask[0] == true) {
+            if(mask.mMask[0]) {
                 i0 = 0;
                 t0 = mVec[0];
             }
-            if(mask.mMask[1] == true && mVec[1] < t0) {
+            if(mask.mMask[1] && mVec[1] < t0) {
                 i0 = 1;
             }
             return i0;
@@ -1393,8 +1393,8 @@ namespace SIMD {
         }
         // MGATHERS
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, uint32_t const * indices) {
-            if (mask.mMask[0] == true) mVec[0] = baseAddr[indices[0]];
-            if (mask.mMask[1] == true) mVec[1] = baseAddr[indices[1]];
+            if (mask.mMask[0]) mVec[0] = baseAddr[indices[0]];
+            if (mask.mMask[1]) mVec[1] = baseAddr[indices[1]];
             return *this;
         }
         // GATHERV
@@ -1405,8 +1405,8 @@ namespace SIMD {
         }
         // MGATHERV
         UME_FORCE_INLINE SIMDVec_u & gather(SIMDVecMask<2> const & mask, uint32_t const * baseAddr, SIMDVec_u const & indices) {
-            if (mask.mMask[0] == true) mVec[0] = baseAddr[indices.mVec[0]];
-            if (mask.mMask[1] == true) mVec[1] = baseAddr[indices.mVec[1]];
+            if (mask.mMask[0]) mVec[0] = baseAddr[indices.mVec[0]];
+            if (mask.mMask[1]) mVec[1] = baseAddr[indices.mVec[1]];
             return *this;
         }
         // SCATTERS
@@ -1417,8 +1417,8 @@ namespace SIMD {
         }
         // MSCATTERS
         UME_FORCE_INLINE uint32_t* scatter(SIMDVecMask<2> const & mask, uint32_t* baseAddr, uint32_t* indices) const {
-            if (mask.mMask[0] == true) baseAddr[indices[0]] = mVec[0];
-            if (mask.mMask[1] == true) baseAddr[indices[1]] = mVec[1];
+            if (mask.mMask[0]) baseAddr[indices[0]] = mVec[0];
+            if (mask.mMask[1]) baseAddr[indices[1]] = mVec[1];
             return baseAddr;
         }
         // SCATTERV
@@ -1429,8 +1429,8 @@ namespace SIMD {
         }
         // MSCATTERV
         UME_FORCE_INLINE uint32_t* scatter(SIMDVecMask<2> const & mask, uint32_t* baseAddr, SIMDVec_u const & indices) const {
-            if (mask.mMask[0] == true) baseAddr[indices.mVec[0]] = mVec[0];
-            if (mask.mMask[1] == true) baseAddr[indices.mVec[1]] = mVec[1];
+            if (mask.mMask[0]) baseAddr[indices.mVec[0]] = mVec[0];
+            if (mask.mMask[1]) baseAddr[indices.mVec[1]] = mVec[1];
             return baseAddr;
         }
 

--- a/unittest/Makefile
+++ b/unittest/Makefile
@@ -5,7 +5,10 @@
 # {FORCE_OPENMP_PLUGIN=ON}
 # {FORCE_SCALAR_PLUGIN=ON}
 
-CXXFLAGS=-std=c++11
+CXXFLAGS=-std=c++14
+CXXCOMPILER=g++
+BUILD=release
+ISA=altivec
 
 ifneq (,$(findstring armclang,$(CXX)))
 	CXXCOMPILER=armclang++
@@ -117,7 +120,7 @@ ifeq ($(ISA), arm)
     endif
 endif
 ifeq ($(ISA), altivec)
-	CXXFLAGS+=-maltivec -mtune=native -mcpu=native -mvsx -mabi=altivec
+	CXXFLAGS+=-mfloat128 -mtune=native -mcpu=native -maltivec -mvsx -mabi=altivec
 	ISA_PREFIX+=_altivec
 endif
 

--- a/unittest/Makefile
+++ b/unittest/Makefile
@@ -113,7 +113,7 @@ endif
 ifeq ($(ISA), arm)
 	ISA_PREFIX+=_arm
     ifeq ($(CXXCOMPILER), g++)
-        CXXFLAGS+=-march=native
+        CXXFLAGS+=-march=armv8-a+simd -ftree-vectorize
     endif
 endif
 ifeq ($(ISA), altivec)

--- a/unittest/Makefile
+++ b/unittest/Makefile
@@ -6,9 +6,6 @@
 # {FORCE_SCALAR_PLUGIN=ON}
 
 CXXFLAGS=-std=c++14
-CXXCOMPILER=g++
-BUILD=release
-ISA=altivec
 
 ifneq (,$(findstring armclang,$(CXX)))
 	CXXCOMPILER=armclang++
@@ -29,7 +26,8 @@ endif
 #some predefined rules
 ifeq ($(CXXCOMPILER), g++)
 	COMPILER_PREFIX=gcc
-	CXXFLAGS+=-W -Wall -pedantic -fstrict-aliasing -Wstrict-aliasing -Woverflow -Werror
+# -Werror
+	CXXFLAGS+=-W -Wall -pedantic -fstrict-aliasing -Wstrict-aliasing -Woverflow
 endif
 ifeq ($(CXXCOMPILER), clang++)
 	COMPILER_PREFIX=clang


### PR DESCRIPTION
gcc62, arm:
In file included from UMEUnitTestSimd128b.h:34:0,
                 from UMEUnitTestSimd128b.cpp:31:
UMEUnitTestCommon.h: In function ‘void genericINSERTTest() [with VEC_TYPE = UME::SIMD::SIMDVec_f<float, 4u>; SCALAR_TYPE = float; int VEC_LEN = 4; DATA_SET = DataSet_1_32f]’:
UMEUnitTestCommon.h:1245:18: warning: ‘vec0.UME::SIMD::SIMDVec_f<float, 4u>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         VEC_TYPE vec0;
                  ^~~~
UMEUnitTestCommon.h:1234:18: warning: ‘vec0.UME::SIMD::SIMDVec_f<float, 4u>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         VEC_TYPE vec0;
                  ^~~~
In file included from UMEUnitTestSimd256b.h:34:0,
                 from UMEUnitTestSimd256b.cpp:31:
UMEUnitTestCommon.h: In static member function ‘static void genericUNPACKTest_random<VEC_TYPE, SCALAR_TYPE, VEC_LEN>::run() [with VEC_TYPE = UME::SIMD::SIMDVec_f<float, 8u>; SCALAR_TYPE = float; int VEC_LEN = 8]’:
UMEUnitTestCommon.h:5782:66: warning: ‘vec0.UME::SIMD::SIMDVec_f<float, 4u>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         typename UME::SIMD::SIMDTraits<VEC_TYPE>::HALF_LEN_VEC_T vec0;
                                                                  ^~~~
UMEUnitTestCommon.h:5783:66: warning: ‘vec1.UME::SIMD::SIMDVec_f<float, 4u>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         typename UME::SIMD::SIMDTraits<VEC_TYPE>::HALF_LEN_VEC_T vec1;
                                                                  ^~~~
UMEUnitTestCommon.h: In function ‘void genericINSERTTest() [with VEC_TYPE = UME::SIMD::SIMDVec_f<double, 2u>; SCALAR_TYPE = double; int VEC_LEN = 2; DATA_SET = DataSet_1_64f]’:
UMEUnitTestCommon.h:1234:18: warning: ‘vec0.UME::SIMD::SIMDVec_f<double, 2u>::mVec’ is used uninitialized in this function [-Wuninitialized]
UMEUnitTestCommon.h:1245:18: warning: ‘vec0.UME::SIMD::SIMDVec_f<double, 2u>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         VEC_TYPE vec0;
                  ^~~~
UMEUnitTestCommon.h: In static member function ‘static void genericPACKTest_random<VEC_TYPE, SCALAR_TYPE, VEC_LEN>::run() [with VEC_TYPE = UME::SIMD::SIMDVec_f<double, 2u>; SCALAR_TYPE = double; int VEC_LEN = 2]’:
UMEUnitTestCommon.h:5637:18: warning: ‘vec2.UME::SIMD::SIMDVec_f<double, 2u>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         VEC_TYPE vec2;
                  ^~~~
UMEUnitTestCommon.h: In static member function ‘static void genericUNPACKTest_random<VEC_TYPE, SCALAR_TYPE, VEC_LEN>::run() [with VEC_TYPE = UME::SIMD::SIMDVec_f<double, 4u>; SCALAR_TYPE = double; int VEC_LEN = 4]’:
UMEUnitTestCommon.h:5783:66: warning: ‘vec1.UME::SIMD::SIMDVec_f<double, 2u>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
UMEUnitTestCommon.h:5782:66: warning: ‘vec0.UME::SIMD::SIMDVec_f<double, 2u>::mVec’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         typename UME::SIMD::SIMDTraits<VEC_TYPE>::HALF_LEN_VEC_T vec0;
